### PR TITLE
replace patch document

### DIFF
--- a/documents.go
+++ b/documents.go
@@ -1,7 +1,12 @@
 package rockset
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/rs/zerolog"
 
@@ -39,36 +44,112 @@ func (rc *RockClient) AddDocuments(ctx context.Context, workspace, collection st
 		return nil, err
 	}
 
-	logResult(log.Trace(), resp.GetData()).Msg("added documents")
+	logDocumentStatuses(log.Trace(), resp.GetData()).Msg("added documents")
 
 	return resp.GetData(), nil
+}
+
+type patchDocumentRequest struct {
+	Data []PatchDocument `json:"data"`
+}
+
+type PatchDocument struct {
+	ID      string           `json:"_id"`
+	Patches []PatchOperation `json:"patch"`
+}
+
+type PatchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+	From  *string     `json:"from"`
 }
 
 // PatchDocuments updates (patches) existing documents in a collection
 //
 // REST API documentation https://docs.rockset.com/rest-api/#patchdocuments
 func (rc *RockClient) PatchDocuments(ctx context.Context, workspace, collection string,
-	docs []openapi.PatchDocument) ([]openapi.DocumentStatus, error) {
+	patches []PatchDocument) ([]openapi.DocumentStatus, error) {
 	var err error
-	var resp openapi.PatchDocumentsResponse
+	var resp *http.Response
 
-	log := zerolog.Ctx(ctx)
-	q := rc.DocumentsApi.PatchDocuments(ctx, workspace, collection)
-
-	req := openapi.NewPatchDocumentsRequest(docs)
-
-	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
-	})
-
+	req, err := rc.patchDocumentsRequest(ctx, workspace, collection, patches)
 	if err != nil {
 		return nil, err
 	}
 
-	logResult(log.Trace(), resp.GetData()).Msg("patched documents")
+	err = rc.Retry(ctx, func() error {
+		resp, err = rc.RockConfig.cfg.HTTPClient.Do(req)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
 
-	return resp.GetData(), nil
+	defer closeAndLog(ctx, resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	log := zerolog.Ctx(ctx)
+
+	// should this accept all 2xx status codes?
+	if resp.StatusCode == http.StatusOK {
+		var pdr openapi.PatchDocumentsResponse
+		if err = json.Unmarshal(body, &pdr); err != nil {
+			return nil, err
+		}
+
+		logDocumentStatuses(log.Trace(), pdr.GetData()).Msg("patched documents")
+
+		return pdr.GetData(), nil
+	}
+
+	// if we get here, something went wrong, see if the error can be extracted from the body
+
+	var em openapi.ErrorModel
+	if err = json.Unmarshal(body, &em); err != nil {
+		log.Error().Err(err).Str("body", string(body)).Msg("failed to unmarshal response")
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return nil, Error{
+		ErrorModel: &em,
+		// TODO: set cause too
+	}
+}
+
+func (rc *RockClient) patchDocumentsRequest(ctx context.Context, ws, collection string,
+	patches []PatchDocument) (*http.Request, error) {
+	data := patchDocumentRequest{Data: patches}
+	payload := bytes.Buffer{}
+	e := json.NewEncoder(&payload)
+	if err := e.Encode(data); err != nil {
+		return nil, err
+	}
+
+	// TODO escape workspace and collection
+	u := fmt.Sprintf("%s/v1/orgs/self/ws/%s/collections/%s/docs", rc.RockConfig.APIServer, ws, collection)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, u, &payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "apikey "+rc.RockConfig.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("x-rockset-version", Version)
+	req.Header.Set("User-Agent", rc.RockConfig.cfg.UserAgent)
+
+	return req, nil
+}
+
+func closeAndLog(ctx context.Context, c io.Closer) {
+	if err := c.Close(); err != nil {
+		log := zerolog.Ctx(ctx)
+		log.Error().Err(err).Msg("failed to close")
+	}
 }
 
 // DeleteDocuments deletes documents from a collection
@@ -98,12 +179,12 @@ func (rc *RockClient) DeleteDocuments(ctx context.Context, workspace, collection
 		return nil, err
 	}
 
-	logResult(log.Trace(), resp.GetData()).Msg("deleted documents")
+	logDocumentStatuses(log.Trace(), resp.GetData()).Msg("deleted documents")
 
 	return resp.GetData(), nil
 }
 
-func logResult(e *zerolog.Event, statuses []openapi.DocumentStatus) *zerolog.Event {
+func logDocumentStatuses(e *zerolog.Event, statuses []openapi.DocumentStatus) *zerolog.Event {
 	result := map[string]int{}
 	for _, s := range statuses {
 		i := result[s.GetStatus()]

--- a/documents.go
+++ b/documents.go
@@ -65,7 +65,9 @@ type PatchOperation struct {
 	From  *string     `json:"from"`
 }
 
-// PatchDocuments updates (patches) existing documents in a collection
+// PatchDocuments patches (updates) existing documents in a collection. This convenience method does not use the
+// generated client, as it takes values as map[string]interface{} which doesn't work when you want to patch e.g.
+// a top-level boolean value.
 //
 // REST API documentation https://docs.rockset.com/rest-api/#patchdocuments
 func (rc *RockClient) PatchDocuments(ctx context.Context, workspace, collection string,
@@ -116,7 +118,7 @@ func (rc *RockClient) PatchDocuments(ctx context.Context, workspace, collection 
 
 	return nil, Error{
 		ErrorModel: &em,
-		// TODO: set cause too
+		Cause:      fmt.Errorf("unexpected http response (%d): %s", resp.StatusCode, resp.Status),
 	}
 }
 
@@ -129,7 +131,7 @@ func (rc *RockClient) patchDocumentsRequest(ctx context.Context, ws, collection 
 		return nil, err
 	}
 
-	// TODO escape workspace and collection
+	// workspace and collection do not need to be escaped as they can only contain alphanumeric or dash characters
 	u := fmt.Sprintf("%s/v1/orgs/self/ws/%s/collections/%s/docs", rc.RockConfig.APIServer, ws, collection)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, u, &payload)
 	if err != nil {

--- a/documents_test.go
+++ b/documents_test.go
@@ -1,24 +1,51 @@
-package rockset
+package rockset_test
 
 import (
-	"bytes"
 	"testing"
 
-	"github.com/rs/zerolog"
+	"github.com/fatih/structs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/rockset/rockset-go-client/openapi"
+	"github.com/rockset/rockset-go-client"
 )
 
-func TestLogResult(t *testing.T) {
-	buf := &bytes.Buffer{}
-	log := zerolog.New(buf).Level(zerolog.TraceLevel).With().Logger()
+func TestRockClient_PatchDocuments(t *testing.T) {
+	skipUnlessIntegrationTest(t)
 
-	logResult(log.Info(), []openapi.DocumentStatus{
-		{Status: openapi.PtrString("foo")},
-		{Status: openapi.PtrString("foo")},
-		{Status: openapi.PtrString("bar")},
-	}).Msg("test")
-	assert.Equal(t, `{"level":"info","foo":2,"bar":1,"message":"test"}
-`, buf.String())
+	ctx := testCtx()
+
+	rc, err := rockset.NewClient()
+	require.NoError(t, err)
+
+	type doc struct {
+		Foo string `json:"foo"`
+		Bar bool   `json:"bar"`
+	}
+
+	var docs = []interface{}{
+		structs.Map(doc{Foo: "foo"}),
+	}
+
+	res, err := rc.AddDocuments(ctx, "tests", "patch", docs)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	patches := []rockset.PatchDocument{
+		{
+			ID: *res[0].Id,
+			Patches: []rockset.PatchOperation{
+				{
+					Op:    "replace",
+					Path:  "/Bar",
+					Value: true,
+				},
+			},
+		},
+	}
+	res, err = rc.PatchDocuments(ctx, "tests", "patch", patches)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	assert.Equal(t, "PATCHED", *res[0].Status)
+	// TODO: verify that it is actually patched too?
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/rockset/rockset-go-client
 go 1.16
 
 require (
+	github.com/fatih/structs v1.1.0
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/rockset/rockset-go-client/openapi v0.12.0
 	github.com/rs/zerolog v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=


### PR DESCRIPTION
`PatchDocuments()` doesn't work when you want to patch a top level column, as the value is a `map[string]interface{}`. This changes makes it so you can e.g. replace a value in the `Bar` column for "document id" using

```
[]rockset.PatchDocument{
		{
			ID: "document id",
			Patches: []rockset.PatchOperation{
				{
					Op:    "replace",
					Path:  "/Bar",
					Value: true,
				},
			},
		},
	}
```