### PR TITLE
add convenience method for streaming writes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/rockset/rockset-go-client
 go 1.16
 
 require (
+	github.com/fatih/structs v1.1.0
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/rockset/rockset-go-client/openapi v0.12.0
 	github.com/rs/zerolog v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,267 @@
+package rockset
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/fatih/structs"
+	"github.com/rs/zerolog"
+
+	"github.com/rockset/rockset-go-client/openapi"
+)
+
+// WriterConfig is a struct containing the configurable parameters for a Writer
+type WriterConfig struct {
+	BufferSize    uint64
+	BatchSize     uint64
+	Workers       uint64
+	FlushInterval time.Duration
+}
+
+// Writer is a helper that writes structs to Rockset collections
+type Writer struct {
+	adder          DocumentAdder
+	config         WriterConfig
+	stats          WriteStats
+	addDocRequests chan addDocRequest
+	buffers        map[string]map[string][]interface{}
+	counter        uint64
+	m              sync.Mutex
+	timeout        *time.Timer
+	timedout       bool
+	wg             sync.WaitGroup
+	workers        int
+	writeRequests  chan WriteRequest
+	stop           chan struct{}
+}
+
+// WriteRequest contains the data to be written to a Rockset collection
+type WriteRequest struct {
+	Workspace  string
+	Collection string
+	Data       interface{}
+}
+
+// WriteStats holds counters for the documents written to Rockset
+type WriteStats struct {
+	DocumentCount uint64
+	ErrorCount    uint64
+}
+
+// NewWriter creates a new Writer
+func NewWriter(conf WriterConfig, adder DocumentAdder) *Writer {
+	return &Writer{
+		adder:          adder,
+		wg:             sync.WaitGroup{},
+		writeRequests:  make(chan WriteRequest, conf.BufferSize),
+		addDocRequests: make(chan addDocRequest, conf.Workers),
+		stop:           make(chan struct{}, 1),
+		buffers:        make(map[string]map[string][]interface{}),
+		config:         conf,
+		stats:          WriteStats{},
+	}
+}
+
+// C returns the WriteRequest channel.
+func (w *Writer) C() chan<- WriteRequest {
+	return w.writeRequests
+}
+
+// DocumentAdder is the interface used to write documents to Rockset.
+type DocumentAdder interface {
+	AddDocuments(ctx context.Context, workspace, collection string, docs []interface{}) ([]openapi.DocumentStatus, error)
+}
+
+// Stop cleanly stops the Writer and flushes any buffered item, and closes the WriteRequest channel.
+func (w *Writer) Stop() {
+	w.stop <- struct{}{}
+}
+
+// Run starts the reader loop that gets write requests from the channel and batches them
+// so the workers can add them to the collection. At least one Worker is needs to be started.
+//
+// rs, err := rockset.NewClient()
+// w := NewWriter(WriterConfig{})
+// w.Run(rs.Documents)
+func (w *Writer) Run(ctx context.Context) {
+	// TODO: should this panic if started more than once?
+	w.wg.Add(1)
+	defer w.wg.Done()
+
+	log := zerolog.Ctx(ctx)
+
+	// this is done to have a timer available for the select
+	w.timeout = time.NewTimer(0)
+	<-w.timeout.C
+	w.timedout = true
+
+	defer func() {
+		if !w.timedout {
+			w.timeout.Stop()
+		}
+	}()
+
+	for {
+		select {
+		case <-w.stop:
+			log.Debug().Msg("stopping writer loop...")
+			close(w.writeRequests)
+			log.Info().Int("counter", len(w.writeRequests)).Msgf("flushing documents")
+			// this can add more than BatchSize to the payload, but as this is the last
+			// time it runs it should be ok
+			for r := range w.writeRequests {
+				w.buffer(r)
+			}
+			w.flush()
+			close(w.addDocRequests)
+			return
+		case <-ctx.Done():
+			log.Debug().Msg("cancelling writer loop...")
+			close(w.writeRequests)
+			// drop queued write requests
+			if len(w.writeRequests) > 0 {
+				log.Warn().Int("counter", len(w.writeRequests)).Msgf("dropping write requests")
+				w.m.Lock()
+				w.stats.ErrorCount += uint64(len(w.writeRequests))
+				w.m.Unlock()
+				for range w.writeRequests {
+					// just drop them on the floor
+				}
+			}
+			close(w.addDocRequests)
+
+			// drop buffered data
+			var counter uint64
+			for _, colls := range w.buffers {
+				for _, data := range colls {
+					counter += uint64(len(data))
+				}
+			}
+			if counter > 0 {
+				w.m.Lock()
+				w.stats.ErrorCount += counter
+				w.m.Unlock()
+				log.Warn().Uint64("counter", counter).Msg("dropping buffer")
+			}
+
+			return
+		case <-w.timeout.C:
+			log.Debug().Uint64("counter", w.counter).Msg("flushing documents due to timeout")
+			w.flush()
+		case r := <-w.writeRequests:
+			w.buffer(r)
+			// only start the timer once we have data in the buffer
+			if w.timedout {
+				w.timedout = false
+				w.timeout = time.NewTimer(w.config.FlushInterval)
+			}
+			if w.counter >= w.config.BatchSize {
+				log.Debug().Uint64("counter", w.counter).Msg("flushing documents due to batch size")
+				w.flush()
+			}
+		}
+	}
+}
+
+type addDocRequest struct {
+	workspace  string
+	collection string
+	data       []interface{}
+}
+
+// Worker runs a worker that writes batches of documents to the Rockset API.
+// It needs to be started as a go routine or it will block.
+func (w *Writer) Worker(ctx context.Context) {
+	w.wg.Add(1)
+	defer w.wg.Done()
+
+	log := zerolog.Ctx(ctx)
+
+	w.m.Lock()
+	index := w.workers
+	w.workers++
+	w.m.Unlock()
+
+	log.Trace().Int("index", index).Msg("worker started")
+
+	for dr := range w.addDocRequests {
+		var errors uint64
+		responses, err := w.adder.AddDocuments(ctx, dr.workspace, dr.collection, dr.data)
+		// TODO recover from panic in AddDocuments
+		var count uint64 = uint64(len(dr.data))
+		if err != nil {
+			w.m.Lock()
+			w.stats.ErrorCount += count
+			w.m.Unlock()
+
+			// TODO: should errors be sent on an error channel instead?
+			log.Error().Msgf("worker #%d error adding %d documents: %v", index, count, err)
+			continue
+		}
+
+		for _, r := range responses {
+			if r.GetStatus() != "ADDED" {
+				errors++
+				log.Error().Str("status", r.GetStatus()).Msg("incorrect status")
+			}
+		}
+		log.Debug().Int("index", index).Uint64("counter", count-errors).Uint64("errors", errors).
+			Str("workspace", dr.workspace).Str("collection", dr.collection).Msg("worker wrote documents")
+		w.m.Lock()
+		w.stats.DocumentCount += count - errors
+		w.stats.ErrorCount += errors
+		w.m.Unlock()
+	}
+
+	log.Debug().Int("index", index).Msg("worker done")
+}
+
+// Wait waits until the reader loop and all workers have finished
+func (w *Writer) Wait() {
+	w.wg.Wait()
+}
+
+// Stats returns a struct with document write statistics
+func (w *Writer) Stats() WriteStats {
+	w.m.Lock()
+	stats := w.stats
+	defer w.m.Unlock()
+	return stats
+}
+
+// Workers returns the number of workers
+func (w *Writer) Workers() int {
+	w.m.Lock()
+	defer w.m.Unlock()
+	return w.workers
+}
+
+// buffer adds WriteRequest into a per workspace and collection buffer
+func (w *Writer) buffer(r WriteRequest) {
+	wsBuffer, found := w.buffers[r.Workspace]
+	if !found {
+		wsBuffer = make(map[string][]interface{})
+		w.buffers[r.Workspace] = wsBuffer
+	}
+
+	w.buffers[r.Workspace][r.Collection] = append(w.buffers[r.Workspace][r.Collection], structs.Map(r.Data))
+	w.counter++
+}
+
+func (w *Writer) flush() {
+	w.timeout.Stop()
+	w.timedout = true
+	for ws, colls := range w.buffers {
+		for coll, data := range colls {
+			w.addDocRequests <- addDocRequest{
+				workspace:  ws,
+				collection: coll,
+				data:       data,
+			}
+		}
+	}
+	// TODO: benchmark to see if it is faster to delete keys as they are flushed instead of creating a new map
+	w.buffers = make(map[string]map[string][]interface{})
+	w.counter = 0
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,0 +1,181 @@
+package rockset_test
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/openapi"
+)
+
+type fakeAdder struct {
+	count int
+}
+
+func (f *fakeAdder) AddDocuments(ctx context.Context, workspace, collection string,
+	docs []interface{}) ([]openapi.DocumentStatus, error) {
+	f.count++
+	time.Sleep(100 * time.Millisecond)
+	return []openapi.DocumentStatus{}, nil
+}
+
+func TestWriter(t *testing.T) {
+	ctx := testCtx()
+	c := rockset.WriterConfig{
+		BufferSize:    30,
+		BatchSize:     7,
+		FlushInterval: time.Millisecond * 50,
+	}
+	fa := &fakeAdder{}
+	w := rockset.NewWriter(c, fa)
+
+	go w.Run(ctx)
+	go w.Worker(ctx)
+
+	const writeCount uint64 = 100
+
+	for i := uint64(0); i < writeCount; i++ {
+		w.C() <- rockset.WriteRequest{
+			Workspace:  "workspace",
+			Collection: "collection",
+			Data:       testObject{Foo: i},
+		}
+	}
+
+	w.Stop()
+	w.Wait()
+
+	assert.Equal(t, uint64(0), w.Stats().ErrorCount)
+	assert.Equal(t, writeCount, w.Stats().DocumentCount)
+}
+
+func TestWriterTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(testCtx())
+	c := rockset.WriterConfig{
+		BufferSize:    30,
+		BatchSize:     7,
+		FlushInterval: time.Millisecond * 10,
+	}
+	fa := &fakeAdder{}
+	w := rockset.NewWriter(c, fa)
+
+	go w.Run(ctx)
+	go w.Worker(ctx)
+
+	w.C() <- rockset.WriteRequest{
+		Workspace:  "workspace",
+		Collection: "collection",
+		Data:       testObject{},
+	}
+	time.Sleep(20 * time.Millisecond)
+	w.C() <- rockset.WriteRequest{
+		Workspace:  "workspace",
+		Collection: "collection",
+		Data:       testObject{},
+	}
+
+	cancel()
+	w.Wait()
+
+	assert.Equal(t, uint64(0), w.Stats().ErrorCount)
+	assert.Equal(t, uint64(1), w.Stats().DocumentCount)
+}
+
+func BenchmarkWriter10(b *testing.B) {
+	c := rockset.WriterConfig{
+		BufferSize:    1000,
+		BatchSize:     10,
+		FlushInterval: time.Millisecond * 500,
+	}
+
+	benchmarkWriter(b, c)
+}
+
+func BenchmarkWriter50(b *testing.B) {
+	c := rockset.WriterConfig{
+		BufferSize:    1000,
+		BatchSize:     50,
+		FlushInterval: time.Millisecond * 500,
+	}
+
+	benchmarkWriter(b, c)
+}
+
+func BenchmarkWriter100(b *testing.B) {
+	c := rockset.WriterConfig{
+		BufferSize:    1000,
+		BatchSize:     100,
+		FlushInterval: time.Millisecond * 500,
+	}
+
+	benchmarkWriter(b, c)
+}
+
+func benchmarkWriter(b *testing.B, c rockset.WriterConfig) {
+	ctx := testCtx()
+	fa := &fakeAdder{}
+	w := rockset.NewWriter(c, fa)
+
+	go w.Run(ctx)
+	go w.Worker(ctx)
+
+	doc := rockset.WriteRequest{
+		Workspace:  "workspace",
+		Collection: "collection",
+		Data:       testObject{},
+	}
+
+	for i := 0; i < b.N; i++ {
+		w.C() <- doc
+	}
+
+	w.Stop()
+	w.Wait()
+}
+
+// go test -v -run TestWriterIntegration -cpuprofile=cpu.out
+// go tool pprof -http=:8080 cpu.out
+
+type testObject struct {
+	Foo uint64
+	Bar string
+}
+
+func TestWriterIntegration(t *testing.T) {
+	skipUnlessIntegrationTest(t)
+	ctx := testCtx()
+
+	rc, err := rockset.NewClient()
+	require.Nil(t, err)
+
+	c := rockset.WriterConfig{
+		BufferSize:    1000,
+		BatchSize:     250,
+		FlushInterval: time.Millisecond * 200,
+	}
+	w := rockset.NewWriter(c, rc)
+
+	go w.Run(ctx)
+	go w.Worker(ctx)
+	go w.Worker(ctx)
+
+	const writeCount uint64 = 10_000
+
+	for i := uint64(0); i < writeCount; i++ {
+		w.C() <- rockset.WriteRequest{
+			Workspace:  "commons",
+			Collection: "writetest",
+			Data:       testObject{i, "test"},
+		}
+	}
+
+	w.Stop()
+	w.Wait()
+
+	assert.Equal(t, uint64(0), w.Stats().ErrorCount)
+	assert.Equal(t, writeCount, w.Stats().DocumentCount)
+}


### PR DESCRIPTION
makes it easy to stream writes to Rockset, e.g. this test:

```
func TestWriter(t *testing.T) {
 	ctx := testCtx()
 	c := rockset.WriterConfig{
 		BufferSize:    30,
 		BatchSize:     7,
 		FlushInterval: time.Millisecond * 50,
 	}
 	fa := &fakeAdder{}
 	w := rockset.NewWriter(c, fa)

 	go w.Run(ctx)
 	go w.Worker(ctx)

 	const writeCount uint64 = 100

 	for i := uint64(0); i < writeCount; i++ {
 		w.C() <- rockset.WriteRequest{
 			Workspace:  "workspace",
 			Collection: "collection",
 			Data:       testObject{Foo: i},
 		}
 	}

 	w.Stop()
 	w.Wait()

 	assert.Equal(t, uint64(0), w.Stats().ErrorCount)
 	assert.Equal(t, writeCount, w.Stats().DocumentCount)
 }
```