### PR TITLE
wrapper to make two parallel queries and return the first result

### DIFF
--- a/ha.go
+++ b/ha.go
@@ -1,0 +1,97 @@
+package rockset
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rs/zerolog"
+
+	"github.com/rockset/rockset-go-client/openapi"
+	"github.com/rockset/rockset-go-client/option"
+)
+
+type Querier interface {
+	Query(context.Context, string, ...option.QueryOption) (openapi.QueryResponse, error)
+}
+
+type HA struct {
+	clients []Querier
+}
+
+func NewHA(client ...Querier) *HA {
+	return &HA{client}
+}
+
+func (ha *HA) Query(ctx context.Context, query string, options ...option.QueryOption) (openapi.QueryResponse, []error) {
+	log := zerolog.Ctx(ctx)
+	// create a sub-context, so we can cancel all HTTP requests after getting the first answer
+	subCtx, cancel := context.WithCancel(ctx)
+
+	// make sure to cancel any pending query result as we don't need them when we return
+	defer cancel()
+
+	var wg sync.WaitGroup
+	resultCh := make(chan openapi.QueryResponse, len(ha.clients))
+	errorCh := make(chan error, len(ha.clients))
+
+	wg.Add(len(ha.clients))
+	for idx, c := range ha.clients {
+		go func(i int, cl Querier) {
+			res, err := cl.Query(ctx, query, options...)
+			if err != nil {
+				log.Error().Err(err).Int("idx", i).Msg("failed to query")
+				errorCh <- err
+			} else {
+				log.Trace().Int("idx", i).Msg("got query response")
+				resultCh <- res
+			}
+			wg.Done()
+		}(idx, c) // avoid using the loop variables as they mutate each iteration
+	}
+
+	// This go routine waits for all parallel query go routines to complete,
+	// which happens once the first request is returned and the rest get cancelled,
+	// or when all requests have failed. It then closes all channels.
+	go func() {
+		wg.Wait()
+		close(resultCh)
+		close(errorCh)
+	}()
+
+	var errors []error
+	for {
+		select {
+		case res, ok := <-resultCh:
+			if !ok {
+				log.Warn().Msg("receive from closed results channel")
+				// avoid getting selected again once the channel is closed, which can happen when we just had errors
+				resultCh = nil
+				continue
+			}
+
+			// log any error we got BEFORE the successful response
+			for _, err := range errors {
+				log.Error().Err(err).Msg("before the response")
+			}
+			// log any error we got AFTER the successful response
+			for err := range errorCh {
+				if err != context.Canceled {
+					log.Error().Err(err).Msg("after the response")
+				}
+			}
+
+			return res, nil
+		case <-subCtx.Done():
+			log.Error().Err(subCtx.Err()).Msg("context cancelled")
+			errors = append(errors, subCtx.Err())
+
+			return openapi.QueryResponse{}, errors
+		case err, ok := <-errorCh:
+			// if the errorCh is closed, ok will be false, and it is time to call it a day
+			if !ok {
+				return openapi.QueryResponse{}, errors
+			}
+			errors = append(errors, err)
+		}
+	}
+}

--- a/ha_test.go
+++ b/ha_test.go
@@ -1,0 +1,137 @@
+package rockset_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/openapi"
+	"github.com/rockset/rockset-go-client/option"
+)
+
+func TestHA_Integration(t *testing.T) {
+	skipUnlessIntegrationTest(t)
+	const apikeyName = "ROCKSET_APIKEY_USE1A1"
+	apikey := os.Getenv(apikeyName)
+	if apikey == "" {
+		t.Skipf("skipping test as %s is not set", apikeyName)
+	}
+
+	ctx := testCtx()
+
+	use1a1, err := rockset.NewClient(rockset.WithAPIServer("https://api.use1a1.rockset.com"),
+		rockset.WithAPIKey(apikey))
+	require.NoError(t, err)
+
+	rs2, err := rockset.NewClient()
+	require.NoError(t, err)
+
+	ha := rockset.NewHA(use1a1, rs2)
+	res, errs := ha.Query(ctx, "SELECT * FROM commons._events LIMIT 10")
+	assert.Len(t, errs, 0)
+
+	assert.Equal(t, "commons._events", (*res.Collections)[0])
+}
+
+func TestHA_OK_FirstFastest(t *testing.T) {
+	ctx := testCtx()
+
+	f0 := newFakeQuerier("0", time.Millisecond, nil)
+	f1 := newFakeQuerier("1", 2*time.Millisecond, nil)
+
+	ha := rockset.NewHA(f0, f1)
+
+	res, errs := ha.Query(ctx, "SELECT 1")
+	require.Nil(t, errs)
+	assert.Equal(t, "0", *res.QueryId)
+}
+
+func TestHA_OK_SecondFastest(t *testing.T) {
+	ctx := testCtx()
+
+	f0 := newFakeQuerier("0", 2*time.Millisecond, nil)
+	f1 := newFakeQuerier("1", time.Millisecond, nil)
+
+	ha := rockset.NewHA(f0, f1)
+
+	res, errs := ha.Query(ctx, "SELECT 1")
+	require.Nil(t, errs)
+	assert.Equal(t, "1", *res.QueryId)
+}
+
+func TestHA_OK_FirstFails(t *testing.T) {
+	ctx := testCtx()
+
+	f0 := newFakeQuerier("0", time.Millisecond, errors.New("failed"))
+	f1 := newFakeQuerier("1", 2*time.Millisecond, nil)
+
+	ha := rockset.NewHA(f0, f1)
+
+	res, errs := ha.Query(ctx, "SELECT 1")
+	require.Nil(t, errs)
+	assert.Equal(t, "1", *res.QueryId)
+}
+
+func TestHA_Fail_BothFail(t *testing.T) {
+	ctx := testCtx()
+
+	f0 := newFakeQuerier("0", time.Millisecond, errors.New("fail0"))
+	f1 := newFakeQuerier("1", 2*time.Millisecond, errors.New("fail1"))
+
+	ha := rockset.NewHA(f0, f1)
+
+	_, errs := ha.Query(ctx, "SELECT 1")
+	require.Len(t, errs, 2)
+	assert.Equal(t, "fail0", errs[0].Error())
+	assert.Equal(t, "fail1", errs[1].Error())
+}
+
+func TestHA_Fail_ContextCancelled(t *testing.T) {
+	ctx := testCtx()
+
+	f0 := newFakeQuerier("0", 10*time.Millisecond, nil)
+	f1 := newFakeQuerier("1", 10*time.Millisecond, nil)
+
+	ha := rockset.NewHA(f0, f1)
+
+	c, cancel := context.WithTimeout(ctx, time.Millisecond)
+	defer cancel()
+
+	_, errs := ha.Query(c, "SELECT 1")
+	require.Len(t, errs, 1)
+}
+
+type fakeQuerier struct {
+	delay    time.Duration
+	err      error
+	response openapi.QueryResponse
+}
+
+func newFakeQuerier(qid string, delay time.Duration, err error) *fakeQuerier {
+	return &fakeQuerier{
+		delay: delay,
+		err:   err,
+		response: openapi.QueryResponse{
+			QueryId: &qid,
+		},
+	}
+}
+
+func (f *fakeQuerier) Query(ctx context.Context, query string, options ...option.QueryOption) (openapi.QueryResponse, error) {
+	select {
+	case <-time.After(f.delay):
+		if f.err != nil {
+			return openapi.QueryResponse{}, f.err
+		}
+		return f.response, nil
+	case <-ctx.Done():
+		return openapi.QueryResponse{}, ctx.Err()
+	}
+
+}


### PR DESCRIPTION
This call wrapper allows you to supply a number of `RockClient`s and it will
run the same query on all API client, but return the first query that it gets back,
or an array of errors.

```
api1, _ := rockset.NewClient()
api2, _ := rockset.NewClient()

ha := rockset.NewHA(api1, api2)
res, errs := ha.Query(ctx, "SELECT * FROM commons._events LIMIT 10")
if errs != nil {
	for _, err := range errs {
		log.Println(err)
	}
	os.Exit(1)
}

log.Println(res)
```

