### PR TITLE
R.I.P. rs2

### DIFF
--- a/documents.go
+++ b/documents.go
@@ -132,7 +132,7 @@ func (rc *RockClient) patchDocumentsRequest(ctx context.Context, ws, collection 
 	}
 
 	// workspace and collection do not need to be escaped as they can only contain alphanumeric or dash characters
-	u := fmt.Sprintf("%s/v1/orgs/self/ws/%s/collections/%s/docs", rc.RockConfig.APIServer, ws, collection)
+	u := fmt.Sprintf("https://%s/v1/orgs/self/ws/%s/collections/%s/docs", rc.RockConfig.APIServer, ws, collection)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, u, &payload)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The rs2 cluster is decomissioned, so the client should not use it as a default any longer.

This also changes the client to require an explicit cluster to be provided using an
environment variable or option to the `NewClient()` call.
