### PR TITLE
update kafka integration & collection support

### DIFF
--- a/collections_kafka_test.go
+++ b/collections_kafka_test.go
@@ -1,0 +1,90 @@
+package rockset_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/option"
+)
+
+type SuiteKafkaCollection struct {
+	suite.Suite
+	rc    *rockset.RockClient
+	name  string
+	ws    string
+	coll  string
+	topic string
+}
+
+func TestSuiteKafkaCollection(t *testing.T) {
+	skipUnlessIntegrationTest(t)
+
+	rc, err := rockset.NewClient()
+	require.NoError(t, err)
+
+	s := SuiteKafkaCollection{
+		rc:    rc,
+		name:  "confluent-cloud-unit-test",
+		ws:    "tests",
+		coll:  "confluent-cloud-unit-test",
+		topic: "test_json",
+	}
+	suite.Run(t, &s)
+}
+
+func (s *SuiteKafkaCollection) SetupSuite() {
+	ctx := testCtx()
+
+	_, err := s.rc.CreateKafkaIntegration(ctx, s.name,
+		option.WithKafkaIntegrationDescription("created by go integration test"),
+		option.WithKafkaV3(),
+		option.WithKafkaBootstrapServers("pkc-pgq85.us-west-2.aws.confluent.cloud:9092"),
+		option.WithKafkaSecurityConfig(
+			"WBQARJNEZDTC57GS",
+			"/cY+gxgLAcVK0SCTuBbNxxm84U2148v/ZcaRsPwMB0KonRhhcg7drw8K9BzvSAzB",
+		),
+	)
+	s.Require().NoError(err)
+}
+
+func (s *SuiteKafkaCollection) TearDownSuite() {
+	ctx := testCtx()
+
+	err := s.rc.DeleteIntegration(ctx, s.name)
+	s.Require().NoError(err)
+}
+
+func (s *SuiteKafkaCollection) TestCreateJSONCollection() {
+	ctx := testCtx()
+
+	_, err := s.rc.CreateKafkaCollection(ctx, s.ws, s.coll,
+		option.WithCollectionDescription("created by go integration test"),
+		option.WithCollectionRetention(time.Hour),
+		option.WithKafkaSource(s.name, s.topic, option.KafkaStartingOffsetEarliest, option.WithJSONFormat(),
+			option.WithKafkaSourceV3(),
+		),
+	)
+	s.Require().NoError(err)
+
+	err = s.rc.WaitUntilCollectionReady(ctx, s.ws, s.name)
+	s.Require().NoError(err)
+
+	// TODO(pmenglund) this should write a document to kafka so we don't need a data generator
+	//  in Confluent Cloud
+	err = s.rc.WaitUntilCollectionDocuments(ctx, s.ws, s.coll, 1)
+	s.Require().NoError(err)
+}
+
+func (s *SuiteKafkaCollection) TestDeleteCollection() {
+	ctx := testCtx()
+
+	err := s.rc.DeleteCollection(ctx, s.ws, s.name)
+	s.Require().NoError(err)
+
+	err = s.rc.WaitUntilCollectionGone(ctx, s.ws, s.coll)
+	s.Require().NoError(err)
+}

--- a/collections_kafka_test.go
+++ b/collections_kafka_test.go
@@ -37,16 +37,16 @@ func TestSuiteKafkaCollection(t *testing.T) {
 }
 
 func (s *SuiteKafkaCollection) SetupSuite() {
+	apikey := skipUnlessEnvSet(s.T(), "CC_KEY")
+	secret := skipUnlessEnvSet(s.T(), "CC_SECRET")
+	bootstrap := skipUnlessEnvSet(s.T(), "CC_BOOTSTRAP_SERVER")
 	ctx := testCtx()
 
 	_, err := s.rc.CreateKafkaIntegration(ctx, s.name,
 		option.WithKafkaIntegrationDescription("created by go integration test"),
 		option.WithKafkaV3(),
-		option.WithKafkaBootstrapServers("pkc-pgq85.us-west-2.aws.confluent.cloud:9092"),
-		option.WithKafkaSecurityConfig(
-			"WBQARJNEZDTC57GS",
-			"/cY+gxgLAcVK0SCTuBbNxxm84U2148v/ZcaRsPwMB0KonRhhcg7drw8K9BzvSAzB",
-		),
+		option.WithKafkaBootstrapServers(bootstrap),
+		option.WithKafkaSecurityConfig(apikey, secret),
 	)
 	s.Require().NoError(err)
 }

--- a/example_s3_test.go
+++ b/example_s3_test.go
@@ -32,10 +32,10 @@ func Example_s3() {
 	// create collection
 	c, err := rc.CreateS3Collection(ctx, "commons", "s3example", "created by go example code",
 		"s3exampleIntegration", "rockset-go-tests", "cities.csv",
-		rockset.WithCSVFormat(
+		option.WithCSVFormat(
 			[]string{"city", "country", "population", "visited"},
-			[]rockset.ColumnType{
-				rockset.ColumnTypeString, rockset.ColumnTypeString, rockset.ColumnTypeInteger, rockset.ColumnTypeBool,
+			[]option.ColumnType{
+				option.ColumnTypeString, option.ColumnTypeString, option.ColumnTypeInteger, option.ColumnTypeBool,
 			},
 			option.WithEncoding("UTF-8"),
 			option.WithEscapeChar("\\"),

--- a/integrations.go
+++ b/integrations.go
@@ -261,7 +261,9 @@ func (rc *RockClient) CreateSegmentIntegration(ctx context.Context, name, connec
 	return resp.GetData(), nil
 }
 
-func (rc *RockClient) CreateKafkaIntegration(ctx context.Context, name string, topics []string, format KafkaFormat,
+// CreateKafkaIntegration create a new integration for a Kafka source.
+// If no format is specified, it defaults to JSON.
+func (rc *RockClient) CreateKafkaIntegration(ctx context.Context, name string,
 	options ...option.KafkaIntegrationOption) (openapi.Integration, error) {
 	var err error
 	var resp *openapi.CreateIntegrationResponse
@@ -274,11 +276,8 @@ func (rc *RockClient) CreateKafkaIntegration(ctx context.Context, name string, t
 		o(&opts)
 	}
 
-	f := format.String()
-	req.Kafka = &openapi.KafkaIntegration{
-		KafkaTopicNames: topics,
-		KafkaDataFormat: &f,
-	}
+	req.Kafka = &opts.Config
+
 	if opts.Description != nil {
 		req.Description = opts.Description
 	}

--- a/option/format.go
+++ b/option/format.go
@@ -1,8 +1,7 @@
-package rockset
+package option
 
 import (
 	"github.com/rockset/rockset-go-client/openapi"
-	"github.com/rockset/rockset-go-client/option"
 )
 
 type Format func(params *openapi.FormatParams)
@@ -18,17 +17,17 @@ func (c ColumnType) String() string {
 }
 
 const (
-	ColumnTypeUnknown ColumnType = iota
-	ColumnTypeBoolean
-	ColumnTypeInteger
-	ColumnTypeFloat
-	ColumnTypeString
-	ColumnTypeTime
-	ColumnTypeDate
-	ColumnTypeDatetime
-	ColumnTypeTimestamp
-	ColumnTypeBool
-	ColumnTypeInt
+	ColumnTypeUnknown   ColumnType = iota
+	ColumnTypeBoolean   ColumnType = iota + 1
+	ColumnTypeInteger   ColumnType = iota + 2
+	ColumnTypeFloat     ColumnType = iota + 3
+	ColumnTypeString    ColumnType = iota + 4
+	ColumnTypeTime      ColumnType = iota + 5
+	ColumnTypeDate      ColumnType = iota + 6
+	ColumnTypeDatetime  ColumnType = iota + 7
+	ColumnTypeTimestamp ColumnType = iota + 8
+	ColumnTypeBool      ColumnType = iota + 9
+	ColumnTypeInt       ColumnType = iota + 10
 )
 
 // WithCSVFormat is used by the create collection calls, to set the format to CSV.
@@ -39,7 +38,7 @@ const (
 //     []ColumnType{ColumnTypeBoolean, ColumnTypeString},
 //     option.WithSeparator(";")
 //   )
-func WithCSVFormat(columnNames []string, columnTypes []ColumnType, options ...option.CSV) Format {
+func WithCSVFormat(columnNames []string, columnTypes []ColumnType, options ...CSV) Format {
 	types := make([]string, len(columnTypes))
 	for i, t := range columnTypes {
 		types[i] = t.String()
@@ -73,6 +72,7 @@ func WithXMLFormat(xml openapi.XmlParams) Format {
 	}
 }
 
+/*
 // KafkaFormat is the definition of the Kafka format
 type KafkaFormat string
 
@@ -87,3 +87,4 @@ const (
 	// KafkaFormatAVRO is the AVRO format for Kafka
 	KafkaFormatAVRO KafkaFormat = "AVRO"
 )
+*/

--- a/option/format.go
+++ b/option/format.go
@@ -18,16 +18,16 @@ func (c ColumnType) String() string {
 
 const (
 	ColumnTypeUnknown   ColumnType = iota
-	ColumnTypeBoolean   ColumnType = iota + 1
-	ColumnTypeInteger   ColumnType = iota + 2
-	ColumnTypeFloat     ColumnType = iota + 3
-	ColumnTypeString    ColumnType = iota + 4
-	ColumnTypeTime      ColumnType = iota + 5
-	ColumnTypeDate      ColumnType = iota + 6
-	ColumnTypeDatetime  ColumnType = iota + 7
-	ColumnTypeTimestamp ColumnType = iota + 8
-	ColumnTypeBool      ColumnType = iota + 9
-	ColumnTypeInt       ColumnType = iota + 10
+	ColumnTypeBoolean   ColumnType = iota
+	ColumnTypeInteger   ColumnType = iota
+	ColumnTypeFloat     ColumnType = iota
+	ColumnTypeString    ColumnType = iota
+	ColumnTypeTime      ColumnType = iota
+	ColumnTypeDate      ColumnType = iota
+	ColumnTypeDatetime  ColumnType = iota
+	ColumnTypeTimestamp ColumnType = iota
+	ColumnTypeBool      ColumnType = iota
+	ColumnTypeInt       ColumnType = iota
 )
 
 // WithCSVFormat is used by the create collection calls, to set the format to CSV.

--- a/rockset_test.go
+++ b/rockset_test.go
@@ -21,9 +21,16 @@ const APIServerEnvironmentVariableName = "ROCKSET_APISERVER"
 
 // helper function to skip unless ROCKSET_APIKEY is set
 func skipUnlessIntegrationTest(t *testing.T) {
-	if os.Getenv(rockset.APIKeyEnvironmentVariableName) == "" {
-		t.Skipf("skipping as %s is not set", rockset.APIKeyEnvironmentVariableName)
+	_ = skipUnlessEnvSet(t, rockset.APIKeyEnvironmentVariableName)
+}
+
+func skipUnlessEnvSet(t *testing.T, envName string) string {
+	env := os.Getenv(envName)
+	if env == "" {
+		t.Skipf("skipping as %s is not set", envName)
 	}
+
+	return env
 }
 
 // helper function to create a context with a zerolog logger


### PR DESCRIPTION
Both the kafka integration and collection have gotten new options. This change adds support for them
and revamps the create collection so that the collection options will be usable in conjunction and 
create a collection from multiple integrations, e.g. S3 and Kafka.


# Test plan
Added a test suite that creates a Confluent Cloud integration, and then a collection from that integration.

```
=== RUN   TestSuiteKafkaCollection
2022-08-30T15:08:45-07:00 TRC api call curation d=909.176542ms
2022-08-30T15:08:45-07:00 DBG total duration d=909.963792ms
=== RUN   TestSuiteKafkaCollection/TestCreateJSONCollection
2022-08-30T15:08:45-07:00 TRC api call curation d=471.724083ms
2022-08-30T15:08:45-07:00 DBG total duration d=471.87675ms
2022-08-30T15:08:46-07:00 TRC api call curation d=184.037083ms
2022-08-30T15:08:46-07:00 DBG total duration d=184.277917ms
2022-08-30T15:08:46-07:00 DBG collectionHasState() collection=confluent-cloud-unit-test status=CREATED workspace=tests
2022-08-30T15:08:46-07:00 DBG call curation d=184.463459ms
2022-08-30T15:08:47-07:00 TRC wait time t="2022-08-30 15:08:47.118756 -0700 PDT m=+2.571387418"
2022-08-30T15:08:47-07:00 TRC api call curation d=155.885875ms
2022-08-30T15:08:47-07:00 DBG total duration d=156.068875ms
2022-08-30T15:08:47-07:00 DBG collectionHasState() collection=confluent-cloud-unit-test status=CREATED workspace=tests
2022-08-30T15:08:47-07:00 DBG call curation d=156.205708ms
2022-08-30T15:08:49-07:00 TRC wait time t="2022-08-30 15:08:49.276037 -0700 PDT m=+4.728669293"
2022-08-30T15:08:49-07:00 TRC api call curation d=118.620208ms
2022-08-30T15:08:49-07:00 DBG total duration d=118.848959ms
2022-08-30T15:08:49-07:00 DBG collectionHasState() collection=confluent-cloud-unit-test status=CREATED workspace=tests
2022-08-30T15:08:49-07:00 DBG call curation d=118.934042ms
2022-08-30T15:08:53-07:00 TRC wait time t="2022-08-30 15:08:53.396122 -0700 PDT m=+8.848753668"
2022-08-30T15:08:53-07:00 TRC api call curation d=135.652125ms
2022-08-30T15:08:53-07:00 DBG total duration d=135.791958ms
2022-08-30T15:08:53-07:00 DBG collectionHasState() collection=confluent-cloud-unit-test status=CREATED workspace=tests
2022-08-30T15:08:53-07:00 DBG call curation d=136.100417ms
2022-08-30T15:09:01-07:00 TRC wait time t="2022-08-30 15:09:01.533483 -0700 PDT m=+16.986114710"
2022-08-30T15:09:01-07:00 TRC api call curation d=73.479584ms
2022-08-30T15:09:01-07:00 DBG total duration d=73.911541ms
2022-08-30T15:09:01-07:00 DBG collectionHasState() collection=confluent-cloud-unit-test status=CREATED workspace=tests
2022-08-30T15:09:01-07:00 DBG call curation d=74.362125ms
2022-08-30T15:09:09-07:00 TRC wait time t="2022-08-30 15:09:09.608753 -0700 PDT m=+25.061384710"
2022-08-30T15:09:09-07:00 TRC api call curation d=73.33525ms
2022-08-30T15:09:09-07:00 DBG total duration d=73.447833ms
2022-08-30T15:09:09-07:00 DBG collectionHasState() collection=confluent-cloud-unit-test status=READY workspace=tests
2022-08-30T15:09:09-07:00 DBG call curation d=73.534ms
2022-08-30T15:09:09-07:00 DBG retry duration d=23.7485085s
2022-08-30T15:09:09-07:00 TRC api call curation d=167.801125ms
2022-08-30T15:09:09-07:00 DBG total duration d=167.972584ms
2022-08-30T15:09:09-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=-1 workspace=tests
2022-08-30T15:09:09-07:00 DBG call curation d=168.188458ms
2022-08-30T15:09:10-07:00 TRC wait time t="2022-08-30 15:09:10.851852 -0700 PDT m=+26.304483501"
2022-08-30T15:09:10-07:00 TRC api call curation d=104.264209ms
2022-08-30T15:09:10-07:00 DBG total duration d=104.401209ms
2022-08-30T15:09:10-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:09:10-07:00 DBG call curation d=104.506917ms
2022-08-30T15:09:12-07:00 TRC wait time t="2022-08-30 15:09:12.95729 -0700 PDT m=+28.409922043"
2022-08-30T15:09:13-07:00 TRC api call curation d=166.64475ms
2022-08-30T15:09:13-07:00 DBG total duration d=166.961833ms
2022-08-30T15:09:13-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:09:13-07:00 DBG call curation d=167.129125ms
2022-08-30T15:09:17-07:00 TRC wait time t="2022-08-30 15:09:17.126118 -0700 PDT m=+32.578749585"
2022-08-30T15:09:17-07:00 TRC api call curation d=131.750167ms
2022-08-30T15:09:17-07:00 DBG total duration d=131.965958ms
2022-08-30T15:09:17-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:09:17-07:00 DBG call curation d=132.100541ms
2022-08-30T15:09:25-07:00 TRC wait time t="2022-08-30 15:09:25.259835 -0700 PDT m=+40.712466335"
2022-08-30T15:09:25-07:00 TRC api call curation d=74.97875ms
2022-08-30T15:09:25-07:00 DBG total duration d=75.108333ms
2022-08-30T15:09:25-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:09:25-07:00 DBG call curation d=75.185834ms
2022-08-30T15:09:33-07:00 TRC wait time t="2022-08-30 15:09:33.336698 -0700 PDT m=+48.789329626"
2022-08-30T15:09:33-07:00 TRC api call curation d=65.787666ms
2022-08-30T15:09:33-07:00 DBG total duration d=65.985958ms
2022-08-30T15:09:33-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:09:33-07:00 DBG call curation d=66.149041ms
2022-08-30T15:09:41-07:00 TRC wait time t="2022-08-30 15:09:41.404404 -0700 PDT m=+56.857035376"
2022-08-30T15:09:41-07:00 TRC api call curation d=117.984833ms
2022-08-30T15:09:41-07:00 DBG total duration d=118.530208ms
2022-08-30T15:09:41-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:09:41-07:00 DBG call curation d=118.902958ms
2022-08-30T15:09:49-07:00 TRC wait time t="2022-08-30 15:09:49.52448 -0700 PDT m=+64.977111460"
2022-08-30T15:09:49-07:00 TRC api call curation d=187.07575ms
2022-08-30T15:09:49-07:00 DBG total duration d=187.18375ms
2022-08-30T15:09:49-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:09:49-07:00 DBG call curation d=187.266583ms
2022-08-30T15:09:57-07:00 TRC wait time t="2022-08-30 15:09:57.712675 -0700 PDT m=+73.165307043"
2022-08-30T15:09:57-07:00 TRC api call curation d=194.804292ms
2022-08-30T15:09:57-07:00 DBG total duration d=194.977792ms
2022-08-30T15:09:57-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:09:57-07:00 DBG call curation d=195.284ms
2022-08-30T15:10:05-07:00 TRC wait time t="2022-08-30 15:10:05.909579 -0700 PDT m=+81.362210626"
2022-08-30T15:10:06-07:00 TRC api call curation d=137.647416ms
2022-08-30T15:10:06-07:00 DBG total duration d=137.766ms
2022-08-30T15:10:06-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:10:06-07:00 DBG call curation d=137.874916ms
2022-08-30T15:10:14-07:00 TRC wait time t="2022-08-30 15:10:14.048306 -0700 PDT m=+89.500937668"
2022-08-30T15:10:14-07:00 TRC api call curation d=81.963541ms
2022-08-30T15:10:14-07:00 DBG total duration d=82.1385ms
2022-08-30T15:10:14-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:10:14-07:00 DBG call curation d=82.312042ms
2022-08-30T15:10:22-07:00 TRC wait time t="2022-08-30 15:10:22.135633 -0700 PDT m=+97.588264376"
2022-08-30T15:10:22-07:00 TRC api call curation d=155.496833ms
2022-08-30T15:10:22-07:00 DBG total duration d=155.641458ms
2022-08-30T15:10:22-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:10:22-07:00 DBG call curation d=155.747542ms
2022-08-30T15:10:30-07:00 TRC wait time t="2022-08-30 15:10:30.293303 -0700 PDT m=+105.745934918"
2022-08-30T15:10:30-07:00 TRC api call curation d=69.884625ms
2022-08-30T15:10:30-07:00 DBG total duration d=70.03075ms
2022-08-30T15:10:30-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:10:30-07:00 DBG call curation d=70.654416ms
2022-08-30T15:10:38-07:00 TRC wait time t="2022-08-30 15:10:38.365508 -0700 PDT m=+113.818139626"
2022-08-30T15:10:38-07:00 TRC api call curation d=181.329542ms
2022-08-30T15:10:38-07:00 DBG total duration d=181.506458ms
2022-08-30T15:10:38-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:10:38-07:00 DBG call curation d=181.6915ms
2022-08-30T15:10:46-07:00 TRC wait time t="2022-08-30 15:10:46.54859 -0700 PDT m=+122.001222126"
2022-08-30T15:10:46-07:00 TRC api call curation d=69.753625ms
2022-08-30T15:10:46-07:00 DBG total duration d=69.914ms
2022-08-30T15:10:46-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:10:46-07:00 DBG call curation d=70.008459ms
2022-08-30T15:10:54-07:00 TRC wait time t="2022-08-30 15:10:54.619809 -0700 PDT m=+130.072440293"
2022-08-30T15:10:54-07:00 TRC api call curation d=170.338333ms
2022-08-30T15:10:54-07:00 DBG total duration d=170.404708ms
2022-08-30T15:10:54-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:10:54-07:00 DBG call curation d=170.460083ms
2022-08-30T15:11:02-07:00 TRC wait time t="2022-08-30 15:11:02.791283 -0700 PDT m=+138.243914835"
2022-08-30T15:11:02-07:00 TRC api call curation d=71.179042ms
2022-08-30T15:11:02-07:00 DBG total duration d=71.428209ms
2022-08-30T15:11:02-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=0 previous=0 workspace=tests
2022-08-30T15:11:02-07:00 DBG call curation d=71.576ms
2022-08-30T15:11:10-07:00 TRC wait time t="2022-08-30 15:11:10.863732 -0700 PDT m=+146.316364085"
2022-08-30T15:11:11-07:00 TRC api call curation d=186.947958ms
2022-08-30T15:11:11-07:00 DBG total duration d=187.138291ms
2022-08-30T15:11:11-07:00 DBG collectionHasNewDocs() collection=confluent-cloud-unit-test count=1 current=6253 previous=0 workspace=tests
2022-08-30T15:11:11-07:00 DBG call curation d=187.234458ms
2022-08-30T15:11:11-07:00 DBG retry duration d=2m1.368576125s
=== RUN   TestSuiteKafkaCollection/TestDeleteCollection
2022-08-30T15:11:11-07:00 TRC api call curation d=93.4005ms
2022-08-30T15:11:11-07:00 DBG total duration d=93.5755ms
2022-08-30T15:11:11-07:00 TRC api call curation d=68.620708ms
2022-08-30T15:11:11-07:00 DBG total duration d=68.749375ms
2022-08-30T15:11:11-07:00 DBG call curation d=68.780541ms
2022-08-30T15:11:12-07:00 TRC wait time t="2022-08-30 15:11:12.2149 -0700 PDT m=+147.667531876"
2022-08-30T15:11:12-07:00 TRC api call curation d=62.382292ms
2022-08-30T15:11:12-07:00 DBG total duration d=62.53125ms
2022-08-30T15:11:12-07:00 DBG call curation d=62.573458ms
2022-08-30T15:11:14-07:00 TRC wait time t="2022-08-30 15:11:14.278909 -0700 PDT m=+149.731540418"
2022-08-30T15:11:14-07:00 TRC api call curation d=117.460042ms
2022-08-30T15:11:14-07:00 DBG total duration d=117.692958ms
2022-08-30T15:11:14-07:00 DBG call curation d=117.772ms
2022-08-30T15:11:18-07:00 TRC wait time t="2022-08-30 15:11:18.39768 -0700 PDT m=+153.850312251"
2022-08-30T15:11:18-07:00 TRC api call curation d=67.849625ms
2022-08-30T15:11:18-07:00 DBG total duration d=68.098833ms
2022-08-30T15:11:18-07:00 DBG call curation d=68.172667ms
2022-08-30T15:11:26-07:00 TRC wait time t="2022-08-30 15:11:26.46681 -0700 PDT m=+161.919442085"
2022-08-30T15:11:26-07:00 TRC api call curation d=295.203167ms
2022-08-30T15:11:26-07:00 DBG total duration d=295.35225ms
2022-08-30T15:11:26-07:00 DBG call curation d=295.407417ms
2022-08-30T15:11:26-07:00 DBG retry duration d=15.617375875s
2022-08-30T15:11:26-07:00 TRC api call curation d=83.608667ms
2022-08-30T15:11:26-07:00 DBG total duration d=83.784916ms
--- PASS: TestSuiteKafkaCollection (162.30s)
    --- PASS: TestSuiteKafkaCollection/TestCreateJSONCollection (145.59s)
    --- PASS: TestSuiteKafkaCollection/TestDeleteCollection (15.71s)
PASS
ok  	github.com/rockset/rockset-go-client	162.657s
```
