### PR TITLE
upgrade to go 1.19 so we can use the enhanced documentation format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
 jobs:
   validation:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     steps:
       - checkout
       - run: go generate ./...
@@ -32,7 +32,7 @@ jobs:
       - run: go vet ./...
   test:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     steps:
       - checkout
       - run: go install github.com/mattn/goveralls@latest
@@ -40,7 +40,7 @@ jobs:
       - run: goveralls -coverprofile=cover.out -service=circle-ci
   release:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     steps:
       - checkout
       - run: go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rockset/rockset-go-client
 
-go 1.18
+go 1.19
 
 require (
 	github.com/confluentinc/confluent-kafka-go v1.9.2


### PR DESCRIPTION
Update to go 1.19 so we can use the new documentation format, and add back `CreateS3Collection()` that was accidentally removed in the previous commit.