### PR TITLE
refactor test

### DIFF
--- a/aliases_test.go
+++ b/aliases_test.go
@@ -3,7 +3,6 @@ package rockset_test
 import (
 	"testing"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -28,15 +27,13 @@ func TestRockClient_ListAliases(t *testing.T) {
 	skipUnlessIntegrationTest(t)
 
 	ctx := testCtx()
-	log := zerolog.Ctx(ctx)
-
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
 	aliases, err := rc.ListAliases(ctx)
 	require.NoError(t, err)
 	for _, a := range aliases {
-		log.Printf("workspace: %s", a.GetName())
+		t.Logf("workspace: %s", a.GetName())
 	}
 }
 
@@ -44,15 +41,13 @@ func TestRockClient_ListAliasesForWorkspace(t *testing.T) {
 	skipUnlessIntegrationTest(t)
 
 	ctx := testCtx()
-	log := zerolog.Ctx(ctx)
-
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
 	aliases, err := rc.ListAliases(ctx, option.WithAliasWorkspace("common"))
 	require.NoError(t, err)
 	for _, a := range aliases {
-		log.Printf("workspace: %s", a.GetName())
+		t.Logf("workspace: %s", a.GetName())
 	}
 }
 
@@ -64,10 +59,10 @@ func TestRockClient_Aliases(t *testing.T) {
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
-	ws := "commons"
-	alias := "randomstring"
+	ws := "acc"
+	alias := randomName(t, "alias")
 
-	_, err = rc.CreateAlias(ctx, ws, alias, []string{"commons.writetest"})
+	_, err = rc.CreateAlias(ctx, ws, alias, []string{"commons._events"})
 	require.NoError(t, err)
 
 	err = rc.WaitUntilAliasAvailable(ctx, ws, alias)

--- a/api_keys_test.go
+++ b/api_keys_test.go
@@ -24,10 +24,11 @@ func TestSuiteAPIKey(t *testing.T) {
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
-	s := SuiteAPIKey{rc: rc, keyName: "integration"}
+	s := SuiteAPIKey{rc: rc, keyName: randomName(t, "key")}
 	suite.Run(t, &s)
 }
 
+// this role is persistent and should always exist
 const IntegrationTestRole = "integration-test"
 
 func (s *SuiteAPIKey) SetupSuite() {

--- a/collections_test.go
+++ b/collections_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"testing"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/rockset/rockset-go-client"
@@ -28,28 +27,25 @@ func TestCollectionTestSuite(t *testing.T) {
 func (s *CollectionTestSuite) TestGetCollection() {
 	ctx := testCtx()
 
-	const cName = "_events"
-	collection, err := s.rc.GetCollection(ctx, "commons", cName)
+	collection, err := s.rc.GetCollection(ctx, persistentWorkspace, persistentCollection)
 	s.NoError(err)
-	s.Assert().Equal(cName, collection.GetName())
+	s.Assert().Equal(persistentCollection, collection.GetName())
 }
 
 func (s *CollectionTestSuite) TestListAllCollections() {
 	ctx := testCtx()
-	log := zerolog.Ctx(ctx)
 
 	collections, err := s.rc.ListCollections(ctx)
 	s.NoError(err)
 
-	log.Debug().Int("count", len(collections)).Msg("collections")
+	s.T().Logf("collections: %d", len(collections))
 }
 
 func (s *CollectionTestSuite) TestListCollectionsInWorkspace() {
 	ctx := testCtx()
-	log := zerolog.Ctx(ctx)
 
-	collections, err := s.rc.ListCollections(ctx, option.WithWorkspace("commons"))
+	collections, err := s.rc.ListCollections(ctx, option.WithWorkspace(persistentWorkspace))
 	s.NoError(err)
 
-	log.Debug().Int("count", len(collections)).Msg("collections")
+	s.T().Logf("collections in %s: %d", persistentWorkspace, len(collections))
 }

--- a/documents_test.go
+++ b/documents_test.go
@@ -27,7 +27,7 @@ func TestRockClient_PatchDocuments(t *testing.T) {
 		structs.Map(doc{Foo: "foo"}),
 	}
 
-	res, err := rc.AddDocuments(ctx, "tests", "patch", docs)
+	res, err := rc.AddDocuments(ctx, persistentWorkspace, "patch", docs)
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 
@@ -43,7 +43,7 @@ func TestRockClient_PatchDocuments(t *testing.T) {
 			},
 		},
 	}
-	res, err = rc.PatchDocuments(ctx, "tests", "patch", patches)
+	res, err = rc.PatchDocuments(ctx, persistentWorkspace, "patch", patches)
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 	assert.Equal(t, "PATCHED", *res[0].Status)

--- a/error_test.go
+++ b/error_test.go
@@ -17,7 +17,7 @@ func TestError_IsNotFoundError(t *testing.T) {
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
-	_, err = rc.GetCollection(ctx, "commons", "notfound")
+	_, err = rc.GetCollection(ctx, persistentWorkspace, "notfound")
 	require.Error(t, err)
 
 	var re rockset.Error

--- a/example_s3_test.go
+++ b/example_s3_test.go
@@ -21,7 +21,7 @@ func Example_s3() {
 	}
 
 	// create integration
-	r, err := rc.CreateS3Integration(ctx, "s3exampleIntegration",
+	r, err := rc.CreateS3Integration(ctx, "exampleS3Integration",
 		option.AWSRole("arn:aws:iam::469279130686:role/rockset-s3-integration"),
 		option.WithS3IntegrationDescription("created by go example code"))
 	if err != nil {
@@ -30,9 +30,9 @@ func Example_s3() {
 	fmt.Printf("integration created: %s\n", r.GetName())
 
 	// create an S3 collection
-	c, err := rc.CreateCollection(ctx, "commons", "s3example",
+	c, err := rc.CreateCollection(ctx, "example", "fromS3",
 		option.WithCollectionDescription("created by go example code"),
-		option.WithS3Source("s3exampleIntegration", "rockset-go-tests",
+		option.WithS3Source("exampleS3Integration", "rockset-go-tests",
 			option.WithCSVFormat(
 				[]string{"city", "country", "population", "visited"},
 				[]option.ColumnType{
@@ -54,52 +54,52 @@ func Example_s3() {
 	fmt.Printf("collection created: %s\n", c.GetName())
 
 	// wait until collection is ready
-	err = rc.WaitUntilCollectionReady(ctx, "commons", "s3example")
+	err = rc.WaitUntilCollectionReady(ctx, "example", "fromS3")
 	if err != nil {
 		log.Fatalf("failed to wait for collection to be ready: %v", err)
 	}
 	fmt.Printf("collection ready: %s\n", c.GetName())
 
 	// wait until there are at least 3 new documents in the collection
-	err = rc.WaitUntilCollectionDocuments(ctx, "commons", "s3example", 3)
+	err = rc.WaitUntilCollectionHasDocuments(ctx, "example", "fromS3", 3)
 	if err != nil {
 		log.Fatalf("failed to wait for new documents: %v", err)
 	}
 
 	// get number of documents
-	collection, err := rc.GetCollection(ctx, "commons", "s3example")
+	collection, err := rc.GetCollection(ctx, "example", "fromS3")
 	if err != nil {
 		log.Fatalf("failed to get collection: %v", err)
 	}
 	fmt.Printf("collection documents: %d\n", collection.Stats.GetDocCount())
 
 	// delete the collection
-	err = rc.DeleteCollection(ctx, "commons", "s3example")
+	err = rc.DeleteCollection(ctx, "example", "fromS3")
 	if err != nil {
 		log.Fatalf("failed to delete collection: %v", err)
 	}
 	fmt.Printf("collection deleted: %s\n", c.GetName())
 
 	// wait until the collection is gone
-	err = rc.WaitUntilCollectionGone(ctx, "commons", "s3example")
+	err = rc.WaitUntilCollectionGone(ctx, "example", "fromS3")
 	if err != nil {
 		log.Fatalf("failed to wait for collection to be gone: %v", err)
 	}
 	fmt.Printf("collection gone: %s\n", c.GetName())
 
 	// delete integration
-	err = rc.DeleteIntegration(ctx, "s3exampleIntegration")
+	err = rc.DeleteIntegration(ctx, "exampleS3Integration")
 	if err != nil {
 		log.Fatalf("failed to delete integration: %v", err)
 	}
 	fmt.Printf("integration deleted: %s\n", r.GetName())
 
 	// Output:
-	// integration created: s3exampleIntegration
-	// collection created: s3example
-	// collection ready: s3example
+	// integration created: exampleS3Integration
+	// collection created: fromS3
+	// collection ready: fromS3
 	// collection documents: 3
-	// collection deleted: s3example
-	// collection gone: s3example
-	// integration deleted: s3exampleIntegration
+	// collection deleted: fromS3
+	// collection gone: fromS3
+	// integration deleted: exampleS3Integration
 }

--- a/queries_test.go
+++ b/queries_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+// for anyone poking around in the code, rockset.sleep() only works for this test org as no sane person would want
+// to add a sleep in their query
 const slowQuery = `script {{{ import * as rockset from "/rockset"; export function delay(x) { rockset.sleep(x); return x; } }}} select _script.delay(2000, q) from unnest([1] as q)`
 
 type QueryTestSuite struct {
@@ -50,7 +52,7 @@ func (s *QueryTestSuite) TestAsyncQuery() {
 	)
 	s.Require().NoError(err)
 
-	err = s.rc.WaitForQuery(ctx, *resp.QueryId)
+	err = s.rc.WaitUntilQueryCompleted(ctx, *resp.QueryId)
 	s.Require().NoError(err)
 
 	_, err = s.rc.GetQueryResults(ctx, *resp.QueryId)

--- a/query_lambdas_test.go
+++ b/query_lambdas_test.go
@@ -3,7 +3,6 @@ package rockset_test
 import (
 	"testing"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -15,25 +14,34 @@ func TestRockClient_CreateQueryLambda(t *testing.T) {
 	skipUnlessIntegrationTest(t)
 
 	ctx := testCtx()
+	ws := "acc"
+	name := randomName(t, "ql")
 
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
-	ql, err := rc.CreateQueryLambda(ctx, "commons", "qlTest", "SELECT 1",
-		option.WithDefaultParameter("", "", ""))
+	ql, err := rc.CreateQueryLambda(ctx, ws, name, "SELECT 1",
+		option.WithDefaultParameter("", "", ""), option.WithQueryLambdaDescription(description()))
 	require.NoError(t, err)
 
 	defer func() {
-		err := rc.DeleteQueryLambda(ctx, "commons", "qlTest")
+		err := rc.DeleteQueryLambda(ctx, ws, name)
 		assert.NoError(t, err)
 	}()
 
-	assert.Equal(t, "qlTest", *ql.Name)
+	assert.Equal(t, name, ql.GetName())
 
-	ql, err = rc.UpdateQueryLambda(ctx, "commons", "qlTest", "SELECT 2",
+	ql, err = rc.UpdateQueryLambda(ctx, ws, name, "SELECT 2",
 		option.WithDefaultParameter("dummy", "string", "foo"))
 	assert.NoError(t, err)
 }
+
+// test fixtures
+const (
+	qlName    = "events"
+	qlVersion = "1921bcad817b5cc2"
+	qlTag     = "test"
+)
 
 func TestRockClient_GetQueryLambdaVersionByTag(t *testing.T) {
 	skipUnlessIntegrationTest(t)
@@ -43,9 +51,9 @@ func TestRockClient_GetQueryLambdaVersionByTag(t *testing.T) {
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
-	version, err := rc.GetQueryLambdaVersionByTag(ctx, "commons", "events", "v2")
+	version, err := rc.GetQueryLambdaVersionByTag(ctx, persistentWorkspace, qlName, qlTag)
 	require.NoError(t, err)
-	assert.Equal(t, "2", *version.Version.Version)
+	assert.Equal(t, qlVersion, version.Version.GetVersion())
 }
 
 func TestRockClient_GetQueryLambdaVersion(t *testing.T) {
@@ -56,17 +64,15 @@ func TestRockClient_GetQueryLambdaVersion(t *testing.T) {
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
-	version, err := rc.GetQueryLambdaVersion(ctx, "commons", "events", "2")
+	version, err := rc.GetQueryLambdaVersion(ctx, persistentWorkspace, qlName, qlVersion)
 	require.NoError(t, err)
-	assert.Equal(t, "events", *version.Name)
+	assert.Equal(t, qlName, version.GetName())
 }
 
 func TestRockClient_ListQueryLambdas(t *testing.T) {
 	skipUnlessIntegrationTest(t)
 
 	ctx := testCtx()
-	log := zerolog.Ctx(ctx)
-
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
@@ -74,7 +80,7 @@ func TestRockClient_ListQueryLambdas(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, l := range lambdas {
-		log.Printf("lambda: %s", *l.Name)
+		t.Logf("lambda: %s", l.GetName())
 	}
 }
 
@@ -86,11 +92,11 @@ func TestRockClient_ListQueryLambdas_workspace(t *testing.T) {
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
-	lambdas, err := rc.ListQueryLambdas(ctx, option.WithQueryLambdaWorkspace("commons"))
+	lambdas, err := rc.ListQueryLambdas(ctx, option.WithQueryLambdaWorkspace(persistentWorkspace))
 	require.NoError(t, err)
 
 	for _, l := range lambdas {
-		assert.Equal(t, "commons", l.GetWorkspace())
+		assert.Equal(t, persistentWorkspace, l.GetWorkspace())
 	}
 }
 
@@ -98,16 +104,15 @@ func TestRockClient_ListQueryLambdaVersions(t *testing.T) {
 	skipUnlessIntegrationTest(t)
 
 	ctx := testCtx()
-	log := zerolog.Ctx(ctx)
 
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
-	versions, err := rc.ListQueryLambdaVersions(ctx, "commons", "events")
+	versions, err := rc.ListQueryLambdaVersions(ctx, persistentWorkspace, qlName)
 	require.NoError(t, err)
 
 	for _, l := range versions {
-		log.Printf("version: %s", *l.Version)
+		t.Logf("version: %s", l.GetVersion())
 	}
 }
 
@@ -115,15 +120,14 @@ func TestRockClient_ListQueryLambdaTags(t *testing.T) {
 	skipUnlessIntegrationTest(t)
 
 	ctx := testCtx()
-	log := zerolog.Ctx(ctx)
 
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
-	tags, err := rc.ListQueryLambdaTags(ctx, "commons", "events")
+	tags, err := rc.ListQueryLambdaTags(ctx, persistentWorkspace, qlName)
 	require.NoError(t, err)
 
 	for _, tag := range tags {
-		log.Printf("tag: %s", *tag.TagName)
+		t.Logf("tag: %s", tag.GetTagName())
 	}
 }

--- a/roles.go
+++ b/roles.go
@@ -7,6 +7,12 @@ import (
 	"github.com/rockset/rockset-go-client/option"
 )
 
+const (
+	ReadOnlyRole = "read-only"
+	MemberRole   = "member"
+	AdminRole    = "admin"
+)
+
 // CreateRole creates a new role
 //
 // REST API documentation https://docs.rockset.com/rest-api/#createrole

--- a/roles_test.go
+++ b/roles_test.go
@@ -1,9 +1,9 @@
 package rockset_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/rockset/rockset-go-client"
@@ -16,8 +16,16 @@ type RoleTestSuite struct {
 	name string
 }
 
-func (s *RoleTestSuite) SetupSuite() {
-	s.name = "foobar"
+func TestRoleTestSuite(t *testing.T) {
+	skipUnlessIntegrationTest(t)
+
+	rc, err := rockset.NewClient()
+	require.NoError(t, err)
+
+	suite.Run(t, &RoleTestSuite{
+		rc:   rc,
+		name: randomName(t, "role"),
+	})
 }
 
 func (s *RoleTestSuite) TearDownSuite() {
@@ -26,21 +34,12 @@ func (s *RoleTestSuite) TearDownSuite() {
 	s.NoError(err)
 }
 
-func TestRoleTestSuite(t *testing.T) {
-	skipUnlessIntegrationTest(t)
-
-	rc, err := rockset.NewClient()
-	require.NoError(t, err)
-
-	suite.Run(t, &RoleTestSuite{rc: rc})
-}
-
 func (s *RoleTestSuite) TestCreateRole() {
 	ctx := testCtx()
 
 	role, err := s.rc.CreateRole(ctx, s.name,
-		option.WithRoleDescription("go client test role"),
-		option.WithWorkspacePrivilege(option.ListResourcesWs, "commons"),
+		option.WithRoleDescription(description()),
+		option.WithWorkspacePrivilege(option.ListResourcesWs, persistentWorkspace),
 	)
 	s.NoError(err)
 	s.Equal(s.name, role.GetRoleName())
@@ -74,7 +73,6 @@ func (s *RoleTestSuite) TestListRoles() {
 		}
 	}
 	s.True(found)
-
 }
 
 func (s *RoleTestSuite) TestUpdate() {

--- a/users_test.go
+++ b/users_test.go
@@ -1,10 +1,11 @@
 package rockset_test
 
 import (
-	"github.com/stretchr/testify/suite"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/rockset/rockset-go-client"
 )
@@ -23,9 +24,10 @@ func TestUserTestSuite(t *testing.T) {
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
+	name := randomName(t, "test")
 	s := UserTestSuite{
 		rc:    rc,
-		email: "pme+testuser@rockset.com",
+		email: fmt.Sprintf("pme+%s@rockset.com", name),
 	}
 	suite.Run(t, &s)
 }
@@ -40,7 +42,7 @@ func (s *UserTestSuite) TearDownSuite() {
 func (s *UserTestSuite) TestCreateUser() {
 	ctx := testCtx()
 
-	_, err := s.rc.CreateUser(ctx, s.email, []string{"read-only"})
+	_, err := s.rc.CreateUser(ctx, s.email, []string{rockset.ReadOnlyRole})
 	s.Require().NoError(err)
 }
 

--- a/views_test.go
+++ b/views_test.go
@@ -16,7 +16,7 @@ func TestListViews(t *testing.T) {
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
-	_, err = rc.ListViews(ctx, option.WithViewWorkspace("commons"))
+	_, err = rc.ListViews(ctx, option.WithViewWorkspace(persistentWorkspace))
 	require.NoError(t, err)
 }
 
@@ -27,15 +27,15 @@ func TestViewCRUD(t *testing.T) {
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
-	ws := "commons"
-	randomName := "not-so-random-name"
+	ws := "acc"
+	name := randomName(t, "view")
 	query := "select * from commons._events where _events.kind = 'COLLECTION'"
-	_, err = rc.CreateView(ctx, ws, randomName, query)
+	_, err = rc.CreateView(ctx, ws, name, query)
 	require.NoError(t, err)
 
-	_, err = rc.UpdateView(ctx, ws, randomName, query, option.WithViewDescription("description"))
+	_, err = rc.UpdateView(ctx, ws, name, query, option.WithViewDescription(description()))
 	require.NoError(t, err)
 
-	err = rc.DeleteView(ctx, ws, randomName)
+	err = rc.DeleteView(ctx, ws, name)
 	require.NoError(t, err)
 }

--- a/virtual_instances_test.go
+++ b/virtual_instances_test.go
@@ -3,7 +3,6 @@ package rockset_test
 import (
 	"testing"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -14,19 +13,16 @@ func TestRockClient_ListVirtualInstances(t *testing.T) {
 	skipUnlessIntegrationTest(t)
 
 	ctx := testCtx()
-	log := zerolog.Ctx(ctx)
-
 	rc, err := rockset.NewClient()
 	require.NoError(t, err)
 
 	vis, err := rc.ListVirtualInstances(ctx)
 	require.NoError(t, err)
-
 	assert.NotEmpty(t, vis)
 
 	for _, vi := range vis {
-		log.Debug().Str("id", vi.GetId()).Str("state", vi.GetState()).
-			Str("type", vi.GetCurrentType()).Str("size", vi.GetCurrentSize()).
-			Msg("virtual instance")
+		t.Logf("vi %s: %s %s %s", vi.GetId(), vi.GetState(), vi.GetCurrentType(), vi.GetCurrentSize())
+		assert.Equal(t, "SMALL", vi.GetCurrentSize())
+		assert.Equal(t, "SMALL", vi.GetDesiredSize())
 	}
 }


### PR DESCRIPTION
- changes the use of static names so that multiple tests can run in parallel
- replaces logging in the test with `t.Logf()`
- refactor azure tests to match the other tests
- fixes a race condition in `WaitUntilCollectionDocuments()` as it is used in the kafka test