### PR TITLE
proper checks for rereyable errors

### DIFF
--- a/api_keys.go
+++ b/api_keys.go
@@ -2,6 +2,7 @@ package rockset
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
@@ -13,6 +14,7 @@ import (
 func (rc *RockClient) CreateAPIKey(ctx context.Context, keyName string,
 	options ...option.APIKeyRoleOption) (openapi.ApiKey, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateApiKeyResponse
 
 	createReq := rc.APIKeysApi.CreateApiKey(ctx)
@@ -28,8 +30,9 @@ func (rc *RockClient) CreateAPIKey(ctx context.Context, keyName string,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = createReq.Body(*b).Execute()
-		return err
+		resp, httpResp, err = createReq.Body(*b).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -48,6 +51,7 @@ const self = "self"
 func (rc *RockClient) GetAPIKey(ctx context.Context, name string,
 	options ...option.APIKeyOption) (openapi.ApiKey, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.GetApiKeyResponse
 
 	opts := option.APIKeyOptions{}
@@ -63,8 +67,9 @@ func (rc *RockClient) GetAPIKey(ctx context.Context, name string,
 	getReq := rc.APIKeysApi.GetApiKey(ctx, user, name).Reveal(opts.Reveal)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = getReq.Execute()
-		return err
+		resp, httpResp, err = getReq.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -80,6 +85,7 @@ func (rc *RockClient) GetAPIKey(ctx context.Context, name string,
 // REST API documentation https://docs.rockset.com/rest-api/#deleteapikey
 func (rc *RockClient) DeleteAPIKey(ctx context.Context, keyName string, options ...option.APIKeyOption) error {
 	var err error
+	var httpResp *http.Response
 
 	opts := option.APIKeyOptions{}
 	for _, o := range options {
@@ -94,8 +100,9 @@ func (rc *RockClient) DeleteAPIKey(ctx context.Context, keyName string, options 
 	getReq := rc.APIKeysApi.DeleteApiKey(ctx, keyName, user)
 
 	err = rc.Retry(ctx, func() error {
-		_, _, err = getReq.Execute()
-		return err
+		_, httpResp, err = getReq.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -111,6 +118,7 @@ func (rc *RockClient) DeleteAPIKey(ctx context.Context, keyName string, options 
 // REST API documentation https://docs.rockset.com/rest-api/#listapikey
 func (rc *RockClient) ListAPIKeys(ctx context.Context, options ...option.APIKeyOption) ([]openapi.ApiKey, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.ListApiKeysResponse
 
 	opts := option.APIKeyOptions{}
@@ -126,8 +134,9 @@ func (rc *RockClient) ListAPIKeys(ctx context.Context, options ...option.APIKeyO
 	getReq := rc.APIKeysApi.ListApiKeys(ctx, user)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = getReq.Execute()
-		return err
+		resp, httpResp, err = getReq.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -144,6 +153,7 @@ func (rc *RockClient) ListAPIKeys(ctx context.Context, options ...option.APIKeyO
 func (rc *RockClient) UpdateAPIKey(ctx context.Context, keyName string,
 	options ...option.APIKeyOption) (openapi.ApiKey, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.UpdateApiKeyResponse
 
 	opts := option.APIKeyOptions{}
@@ -164,8 +174,9 @@ func (rc *RockClient) UpdateAPIKey(ctx context.Context, keyName string,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = updateReq.Execute()
-		return err
+		resp, httpResp, err = updateReq.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {

--- a/collections.go
+++ b/collections.go
@@ -2,6 +2,7 @@ package rockset
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/rockset/rockset-go-client/openapi"
@@ -11,13 +12,14 @@ import (
 // GetCollection gets information about a collection.
 func (rc *RockClient) GetCollection(ctx context.Context, workspace, name string) (openapi.Collection, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.GetCollectionResponse
 	getReq := rc.CollectionsApi.GetCollection(ctx, workspace, name)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = getReq.Execute()
+		resp, httpResp, err = getReq.Execute()
 
-		return err
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -31,6 +33,7 @@ func (rc *RockClient) GetCollection(ctx context.Context, workspace, name string)
 func (rc *RockClient) ListCollections(ctx context.Context,
 	options ...option.ListCollectionOption) ([]openapi.Collection, error) {
 	var err error
+	var httpResp *http.Response
 
 	opts := option.ListCollectionOptions{}
 
@@ -43,17 +46,17 @@ func (rc *RockClient) ListCollections(ctx context.Context,
 	if opts.Workspace == nil {
 		listReq := rc.CollectionsApi.ListCollections(ctx)
 		err = rc.Retry(ctx, func() error {
-			resp, _, err = listReq.Execute()
+			resp, httpResp, err = listReq.Execute()
 
-			return err
+			return NewErrorWithStatusCode(err, httpResp.StatusCode)
 		})
 	} else {
 		listWsReq := rc.CollectionsApi.WorkspaceCollections(ctx, *opts.Workspace)
 
 		err = rc.Retry(ctx, func() error {
-			resp, _, err = listWsReq.Execute()
+			resp, httpResp, err = listWsReq.Execute()
 
-			return err
+			return NewErrorWithStatusCode(err, httpResp.StatusCode)
 		})
 	}
 
@@ -69,9 +72,9 @@ func (rc *RockClient) DeleteCollection(ctx context.Context, workspace, name stri
 	deleteReq := rc.CollectionsApi.DeleteCollection(ctx, workspace, name)
 
 	err := rc.Retry(ctx, func() error {
-		_, _, err := deleteReq.Execute()
+		_, httpResp, err := deleteReq.Execute()
 
-		return err
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	return err
@@ -113,6 +116,7 @@ func (rc *RockClient) DeleteCollection(ctx context.Context, workspace, name stri
 func (rc *RockClient) CreateCollection(ctx context.Context, workspace, name string,
 	options ...option.CollectionOption) (openapi.Collection, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateCollectionResponse
 
 	request := openapi.CreateCollectionRequest{}
@@ -125,8 +129,9 @@ func (rc *RockClient) CreateCollection(ctx context.Context, workspace, name stri
 	createReq := rc.CollectionsApi.CreateCollection(ctx, workspace)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = createReq.Body(request).Execute()
-		return err
+		resp, httpResp, err = createReq.Body(request).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 	if err != nil {
 		return openapi.Collection{}, err
@@ -162,6 +167,7 @@ func (rc *RockClient) CreateKinesisCollection(ctx context.Context,
 	workspace, name, description, integration, region, stream string,
 	format option.Format, options ...option.CollectionOption) (openapi.Collection, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateCollectionResponse
 
 	createReq := rc.CollectionsApi.CreateCollection(ctx, workspace)
@@ -188,8 +194,9 @@ func (rc *RockClient) CreateKinesisCollection(ctx context.Context,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = createReq.Body(*createParams).Execute()
-		return err
+		resp, httpResp, err = createReq.Body(*createParams).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -203,6 +210,7 @@ func (rc *RockClient) CreateGCSCollection(ctx context.Context,
 	workspace, name, description, integration, bucket, prefix string,
 	format option.Format, options ...option.CollectionOption) (openapi.Collection, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateCollectionResponse
 
 	createReq := rc.CollectionsApi.CreateCollection(ctx, workspace)
@@ -229,8 +237,9 @@ func (rc *RockClient) CreateGCSCollection(ctx context.Context,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = createReq.Body(*createParams).Execute()
-		return err
+		resp, httpResp, err = createReq.Body(*createParams).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -244,6 +253,7 @@ func (rc *RockClient) CreateDynamoDBCollection(ctx context.Context,
 	workspace, name, description, integration, region, tableName string, maxRCU int64,
 	format option.Format, options ...option.CollectionOption) (openapi.Collection, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateCollectionResponse
 
 	createReq := rc.CollectionsApi.CreateCollection(ctx, workspace)
@@ -270,8 +280,9 @@ func (rc *RockClient) CreateDynamoDBCollection(ctx context.Context,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = createReq.Body(*createParams).Execute()
-		return err
+		resp, httpResp, err = createReq.Body(*createParams).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -286,6 +297,7 @@ func (rc *RockClient) CreateFileUploadCollection(ctx context.Context,
 	fileUploadTime time.Time,
 	format option.Format, options ...option.CollectionOption) (openapi.Collection, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateCollectionResponse
 
 	createReq := rc.CollectionsApi.CreateCollection(ctx, workspace)
@@ -312,8 +324,9 @@ func (rc *RockClient) CreateFileUploadCollection(ctx context.Context,
 		o(createParams)
 	}
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = createReq.Body(*createParams).Execute()
-		return err
+		resp, httpResp, err = createReq.Body(*createParams).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 	if err != nil {
 		return openapi.Collection{}, err
@@ -341,6 +354,7 @@ func (rc *RockClient) CreateFileUploadCollection(ctx context.Context,
 func (rc *RockClient) CreateKafkaCollection(ctx context.Context, workspace, name string,
 	options ...option.CollectionOption) (openapi.Collection, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateCollectionResponse
 
 	createReq := rc.CollectionsApi.CreateCollection(ctx, workspace)
@@ -354,8 +368,9 @@ func (rc *RockClient) CreateKafkaCollection(ctx context.Context, workspace, name
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = createReq.Body(*createParams).Execute()
-		return err
+		resp, httpResp, err = createReq.Body(*createParams).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -369,6 +384,7 @@ func (rc *RockClient) CreateMongoDBCollection(ctx context.Context,
 	workspace, name, description, integration, database, collection string,
 	format option.Format, options ...option.CollectionOption) (openapi.Collection, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateCollectionResponse
 
 	createReq := rc.CollectionsApi.CreateCollection(ctx, workspace)
@@ -395,8 +411,9 @@ func (rc *RockClient) CreateMongoDBCollection(ctx context.Context,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = createReq.Body(*createParams).Execute()
-		return err
+		resp, httpResp, err = createReq.Body(*createParams).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 	if err != nil {
 		return openapi.Collection{}, err

--- a/documents.go
+++ b/documents.go
@@ -21,6 +21,7 @@ import (
 func (rc *RockClient) AddDocuments(ctx context.Context, workspace, collection string,
 	docs []interface{}) ([]openapi.DocumentStatus, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.AddDocumentsResponse
 
 	log := zerolog.Ctx(ctx)
@@ -36,8 +37,9 @@ func (rc *RockClient) AddDocuments(ctx context.Context, workspace, collection st
 	req := openapi.NewAddDocumentsRequest(payload)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -82,7 +84,8 @@ func (rc *RockClient) PatchDocuments(ctx context.Context, workspace, collection 
 
 	err = rc.Retry(ctx, func() error {
 		resp, err = rc.RockConfig.cfg.HTTPClient.Do(req)
-		return err
+
+		return NewErrorWithStatusCode(err, resp.StatusCode)
 	})
 	if err != nil {
 		return nil, err
@@ -160,6 +163,7 @@ func closeAndLog(ctx context.Context, c io.Closer) {
 func (rc *RockClient) DeleteDocuments(ctx context.Context, workspace, collection string,
 	docIDs []string) ([]openapi.DocumentStatus, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.DeleteDocumentsResponse
 
 	log := zerolog.Ctx(ctx)
@@ -173,8 +177,9 @@ func (rc *RockClient) DeleteDocuments(ctx context.Context, workspace, collection
 	req := openapi.NewDeleteDocumentsRequest(ids)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {

--- a/integrations.go
+++ b/integrations.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
+	"net/http"
 )
 
 func (rc *RockClient) GetIntegration(ctx context.Context, name string) (openapi.Integration, error) {
 	var err error
+	var httpResp *http.Response
 	req := rc.IntegrationsApi.GetIntegration(ctx, name)
 
 	var resp *openapi.GetIntegrationResponse
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = req.Execute()
-		return err
+		resp, httpResp, err = req.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 	if err != nil {
 		return openapi.Integration{}, err
@@ -24,12 +27,14 @@ func (rc *RockClient) GetIntegration(ctx context.Context, name string) (openapi.
 
 func (rc *RockClient) ListIntegrations(ctx context.Context) ([]openapi.Integration, error) {
 	var err error
+	var httpResp *http.Response
 	req := rc.IntegrationsApi.ListIntegrations(ctx)
 
 	var resp *openapi.ListIntegrationsResponse
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = req.Execute()
-		return err
+		resp, httpResp, err = req.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 	if err != nil {
 		return nil, err
@@ -40,11 +45,13 @@ func (rc *RockClient) ListIntegrations(ctx context.Context) ([]openapi.Integrati
 
 func (rc *RockClient) DeleteIntegration(ctx context.Context, name string) error {
 	var err error
+	var httpResp *http.Response
 	req := rc.IntegrationsApi.DeleteIntegration(ctx, name)
 
 	err = rc.Retry(ctx, func() error {
-		_, _, err = req.Execute()
-		return err
+		_, httpResp, err = req.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	return err
@@ -55,6 +62,7 @@ func (rc *RockClient) DeleteIntegration(ctx context.Context, name string) error 
 func (rc *RockClient) CreateAzureBlobStorageIntegration(ctx context.Context, name string,
 	connection string) (openapi.Integration, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateIntegrationResponse
 	q := rc.IntegrationsApi.CreateIntegration(ctx)
 	req := openapi.NewCreateIntegrationRequest(name)
@@ -64,8 +72,9 @@ func (rc *RockClient) CreateAzureBlobStorageIntegration(ctx context.Context, nam
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -78,6 +87,7 @@ func (rc *RockClient) CreateAzureBlobStorageIntegration(ctx context.Context, nam
 func (rc *RockClient) CreateS3Integration(ctx context.Context, name string, creds option.AWSCredentialsFn,
 	options ...option.S3IntegrationOption) (openapi.Integration, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateIntegrationResponse
 
 	q := rc.IntegrationsApi.CreateIntegration(ctx)
@@ -104,8 +114,9 @@ func (rc *RockClient) CreateS3Integration(ctx context.Context, name string, cred
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -118,6 +129,7 @@ func (rc *RockClient) CreateS3Integration(ctx context.Context, name string, cred
 func (rc *RockClient) CreateKinesisIntegration(ctx context.Context, name string, creds option.AWSCredentialsFn,
 	options ...option.KinesisIntegrationOption) (openapi.Integration, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateIntegrationResponse
 	q := rc.IntegrationsApi.CreateIntegration(ctx)
 	req := openapi.NewCreateIntegrationRequest(name)
@@ -142,8 +154,9 @@ func (rc *RockClient) CreateKinesisIntegration(ctx context.Context, name string,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -158,6 +171,7 @@ func (rc *RockClient) CreateKinesisIntegration(ctx context.Context, name string,
 func (rc *RockClient) CreateDynamoDBIntegration(ctx context.Context, name string, creds option.AWSCredentialsFn,
 	s3BucketName string, options ...option.DynamoDBIntegrationOption) (openapi.Integration, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateIntegrationResponse
 
 	q := rc.IntegrationsApi.CreateIntegration(ctx)
@@ -185,8 +199,9 @@ func (rc *RockClient) CreateDynamoDBIntegration(ctx context.Context, name string
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -199,6 +214,7 @@ func (rc *RockClient) CreateDynamoDBIntegration(ctx context.Context, name string
 func (rc *RockClient) CreateGCSIntegration(ctx context.Context, name, serviceAccountKeyFileJSON string,
 	options ...option.GCSIntegrationOption) (openapi.Integration, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateIntegrationResponse
 
 	q := rc.IntegrationsApi.CreateIntegration(ctx)
@@ -219,8 +235,9 @@ func (rc *RockClient) CreateGCSIntegration(ctx context.Context, name, serviceAcc
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -235,6 +252,7 @@ func (rc *RockClient) CreateGCSIntegration(ctx context.Context, name, serviceAcc
 func (rc *RockClient) CreateKafkaIntegration(ctx context.Context, name string,
 	options ...option.KafkaIntegrationOption) (openapi.Integration, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateIntegrationResponse
 
 	q := rc.IntegrationsApi.CreateIntegration(ctx)
@@ -252,8 +270,9 @@ func (rc *RockClient) CreateKafkaIntegration(ctx context.Context, name string,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -266,6 +285,7 @@ func (rc *RockClient) CreateKafkaIntegration(ctx context.Context, name string,
 func (rc *RockClient) CreateMongoDBIntegration(ctx context.Context, name, connectionURI string,
 	options ...option.MongoDBIntegrationOption) (openapi.Integration, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateIntegrationResponse
 
 	q := rc.IntegrationsApi.CreateIntegration(ctx)
@@ -284,8 +304,9 @@ func (rc *RockClient) CreateMongoDBIntegration(ctx context.Context, name, connec
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {

--- a/organizations.go
+++ b/organizations.go
@@ -2,6 +2,7 @@ package rockset
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/rs/zerolog"
 
@@ -11,13 +12,15 @@ import (
 // GetOrganization gets the current organization.
 func (rc *RockClient) GetOrganization(ctx context.Context) (openapi.Organization, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.OrganizationResponse
 	log := zerolog.Ctx(ctx)
 	getReq := rc.OrganizationsApi.GetOrganization(ctx)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = getReq.Execute()
-		return err
+		resp, httpResp, err = getReq.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {

--- a/queries.go
+++ b/queries.go
@@ -2,9 +2,9 @@ package rockset
 
 import (
 	"context"
-
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
+	"net/http"
 )
 
 type QueryState string
@@ -21,6 +21,7 @@ const (
 func (rc *RockClient) Query(ctx context.Context, sql string,
 	options ...option.QueryOption) (openapi.QueryResponse, error) {
 	var err error
+	var httpResp *http.Response
 	var response *openapi.QueryResponse
 
 	q := rc.QueriesApi.Query(ctx)
@@ -33,8 +34,9 @@ func (rc *RockClient) Query(ctx context.Context, sql string,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		response, _, err = q.Body(*rq).Execute()
-		return err
+		response, httpResp, err = q.Body(*rq).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -48,6 +50,7 @@ func (rc *RockClient) Query(ctx context.Context, sql string,
 func (rc *RockClient) ValidateQuery(ctx context.Context, sql string,
 	options ...option.QueryOption) (openapi.ValidateQueryResponse, error) {
 	var err error
+	var httpResp *http.Response
 	var r *openapi.ValidateQueryResponse
 
 	q := rc.QueriesApi.Validate(ctx)
@@ -61,8 +64,9 @@ func (rc *RockClient) ValidateQuery(ctx context.Context, sql string,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		r, _, err = q.Body(*rq).Execute()
-		return err
+		r, httpResp, err = q.Body(*rq).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -75,13 +79,15 @@ func (rc *RockClient) ValidateQuery(ctx context.Context, sql string,
 // GetQueryInfo retrieves information about a query.
 func (rc *RockClient) GetQueryInfo(ctx context.Context, queryID string) (openapi.QueryInfo, error) {
 	var err error
+	var httpResp *http.Response
 	var response *openapi.GetQueryResponse
 
 	q := rc.QueriesApi.GetQuery(ctx, queryID)
 
 	err = rc.Retry(ctx, func() error {
-		response, _, err = q.Execute()
-		return err
+		response, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -94,13 +100,15 @@ func (rc *RockClient) GetQueryInfo(ctx context.Context, queryID string) (openapi
 // GetQueryResults retrieves the results of a completed async query.
 func (rc *RockClient) GetQueryResults(ctx context.Context, queryID string) (openapi.QueryPaginationResponse, error) {
 	var err error
+	var httpResp *http.Response
 	var response *openapi.QueryPaginationResponse
 
 	q := rc.QueriesApi.GetQueryResults(ctx, queryID)
 
 	err = rc.Retry(ctx, func() error {
-		response, _, err = q.Execute()
-		return err
+		response, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -113,13 +121,15 @@ func (rc *RockClient) GetQueryResults(ctx context.Context, queryID string) (open
 // ListActiveQueries lists all active queries, i.e. queued or running.
 func (rc *RockClient) ListActiveQueries(ctx context.Context) ([]openapi.QueryInfo, error) {
 	var err error
+	var httpResp *http.Response
 	var response *openapi.ListQueriesResponse
 
 	q := rc.QueriesApi.ListActiveQueries(ctx)
 
 	err = rc.Retry(ctx, func() error {
-		response, _, err = q.Execute()
-		return err
+		response, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	return response.Data, nil
@@ -128,13 +138,15 @@ func (rc *RockClient) ListActiveQueries(ctx context.Context) ([]openapi.QueryInf
 // CancelQuery cancels a queued or running query.
 func (rc *RockClient) CancelQuery(ctx context.Context, queryID string) (openapi.QueryInfo, error) {
 	var err error
+	var httpResp *http.Response
 	var response *openapi.CancelQueryResponse
 
 	q := rc.QueriesApi.CancelQuery(ctx, queryID)
 
 	err = rc.Retry(ctx, func() error {
-		response, _, err = q.Execute()
-		return err
+		response, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	return *response.Data, nil

--- a/query_lambdas.go
+++ b/query_lambdas.go
@@ -3,6 +3,7 @@ package rockset
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
@@ -17,6 +18,7 @@ const LatestTag = "latest"
 func (rc *RockClient) CreateQueryLambda(ctx context.Context, workspace, name, sql string,
 	options ...option.CreateQueryLambdaOption) (openapi.QueryLambdaVersion, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.QueryLambdaVersionResponse
 
 	q := rc.QueryLambdasApi.CreateQueryLambda(ctx, workspace)
@@ -41,8 +43,9 @@ func (rc *RockClient) CreateQueryLambda(ctx context.Context, workspace, name, sq
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -57,12 +60,14 @@ func (rc *RockClient) CreateQueryLambda(ctx context.Context, workspace, name, sq
 // https://docs.rockset.com/rest-api/#deletequerylambda
 func (rc *RockClient) DeleteQueryLambda(ctx context.Context, workspace, name string) error {
 	var err error
+	var httpResp *http.Response
 
 	q := rc.QueryLambdasApi.DeleteQueryLambda(ctx, workspace, name)
 
 	err = rc.Retry(ctx, func() error {
-		_, _, err = q.Execute()
-		return err
+		_, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -78,6 +83,7 @@ func (rc *RockClient) DeleteQueryLambda(ctx context.Context, workspace, name str
 func (rc *RockClient) UpdateQueryLambda(ctx context.Context, workspace, name, sql string,
 	options ...option.CreateQueryLambdaOption) (openapi.QueryLambdaVersion, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.QueryLambdaVersionResponse
 
 	q := rc.QueryLambdasApi.UpdateQueryLambda(ctx, workspace, name)
@@ -101,8 +107,9 @@ func (rc *RockClient) UpdateQueryLambda(ctx context.Context, workspace, name, sq
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -118,6 +125,7 @@ func (rc *RockClient) UpdateQueryLambda(ctx context.Context, workspace, name, sq
 func (rc *RockClient) CreateQueryLambdaTag(ctx context.Context, workspace, name, version,
 	tag string) (openapi.QueryLambdaTag, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.QueryLambdaTagResponse
 
 	q := rc.QueryLambdasApi.CreateQueryLambdaTag(ctx, workspace, name)
@@ -127,8 +135,9 @@ func (rc *RockClient) CreateQueryLambdaTag(ctx context.Context, workspace, name,
 	req.Version = version
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -143,11 +152,13 @@ func (rc *RockClient) CreateQueryLambdaTag(ctx context.Context, workspace, name,
 // https://docs.rockset.com/rest-api/#deletequerylambdaversion
 func (rc *RockClient) DeleteQueryLambdaVersion(ctx context.Context, workspace, name, version string) error {
 	var err error
+	var httpResp *http.Response
 
 	q := rc.QueryLambdasApi.DeleteQueryLambdaVersion(ctx, workspace, name, version)
 	err = rc.Retry(ctx, func() error {
-		_, _, err = q.Execute()
-		return err
+		_, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -162,11 +173,13 @@ func (rc *RockClient) DeleteQueryLambdaVersion(ctx context.Context, workspace, n
 // https://docs.rockset.com/rest-api/#deletequerylambdatag
 func (rc *RockClient) DeleteQueryLambdaTag(ctx context.Context, workspace, name, tag string) error {
 	var err error
+	var httpResp *http.Response
 
 	q := rc.QueryLambdasApi.DeleteQueryLambdaTag(ctx, workspace, name, tag)
 	err = rc.Retry(ctx, func() error {
-		_, _, err = q.Execute()
-		return err
+		_, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -192,24 +205,28 @@ func (rc *RockClient) ExecuteQueryLambda(ctx context.Context, workspace, name st
 	}
 
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.QueryResponse
 	if req.Version != "" {
 		q := rc.QueryLambdasApi.ExecuteQueryLambda(ctx, workspace, name, req.Version)
 		err = rc.Retry(ctx, func() error {
-			resp, _, err = q.Body(req.ExecuteQueryLambdaRequest).Execute()
-			return err
+			resp, httpResp, err = q.Body(req.ExecuteQueryLambdaRequest).Execute()
+
+			return NewErrorWithStatusCode(err, httpResp.StatusCode)
 		})
 	} else if req.Tag != "" {
 		q := rc.QueryLambdasApi.ExecuteQueryLambdaByTag(ctx, workspace, name, req.Tag)
 		err = rc.Retry(ctx, func() error {
-			resp, _, err = q.Body(req.ExecuteQueryLambdaRequest).Execute()
-			return err
+			resp, httpResp, err = q.Body(req.ExecuteQueryLambdaRequest).Execute()
+
+			return NewErrorWithStatusCode(err, httpResp.StatusCode)
 		})
 	} else {
 		q := rc.QueryLambdasApi.ExecuteQueryLambdaByTag(ctx, workspace, name, LatestTag)
 		err = rc.Retry(ctx, func() error {
-			resp, _, err = q.Body(req.ExecuteQueryLambdaRequest).Execute()
-			return err
+			resp, httpResp, err = q.Body(req.ExecuteQueryLambdaRequest).Execute()
+
+			return NewErrorWithStatusCode(err, httpResp.StatusCode)
 		})
 	}
 
@@ -224,12 +241,14 @@ func (rc *RockClient) ExecuteQueryLambda(ctx context.Context, workspace, name st
 func (rc *RockClient) GetQueryLambdaVersionByTag(ctx context.Context,
 	workspace, name, tag string) (openapi.QueryLambdaTag, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.QueryLambdaTagResponse
 
 	q := rc.QueryLambdasApi.GetQueryLambdaTagVersion(ctx, workspace, name, tag)
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Execute()
-		return err
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -243,12 +262,14 @@ func (rc *RockClient) GetQueryLambdaVersionByTag(ctx context.Context,
 func (rc *RockClient) GetQueryLambdaVersion(ctx context.Context,
 	workspace, name, version string) (openapi.QueryLambdaVersion, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.QueryLambdaVersionResponse
 
 	q := rc.QueryLambdasApi.GetQueryLambdaVersion(ctx, workspace, name, version)
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Execute()
-		return err
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -264,6 +285,7 @@ func (rc *RockClient) GetQueryLambdaVersion(ctx context.Context,
 func (rc *RockClient) ListQueryLambdas(ctx context.Context,
 	options ...option.ListQueryLambdaOption) ([]openapi.QueryLambda, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.ListQueryLambdasResponse
 
 	opts := option.ListQueryLambdaOptions{}
@@ -274,14 +296,16 @@ func (rc *RockClient) ListQueryLambdas(ctx context.Context,
 	if opts.Workspace == nil {
 		q := rc.QueryLambdasApi.ListAllQueryLambdas(ctx)
 		err = rc.Retry(ctx, func() error {
-			resp, _, err = q.Execute()
-			return err
+			resp, httpResp, err = q.Execute()
+
+			return NewErrorWithStatusCode(err, httpResp.StatusCode)
 		})
 	} else {
 		q := rc.QueryLambdasApi.ListQueryLambdasInWorkspace(ctx, *opts.Workspace)
 		err = rc.Retry(ctx, func() error {
-			resp, _, err = q.Execute()
-			return err
+			resp, httpResp, err = q.Execute()
+
+			return NewErrorWithStatusCode(err, httpResp.StatusCode)
 		})
 	}
 
@@ -296,12 +320,14 @@ func (rc *RockClient) ListQueryLambdas(ctx context.Context,
 func (rc *RockClient) ListQueryLambdaVersions(ctx context.Context,
 	workspace, name string) ([]openapi.QueryLambdaVersion, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.ListQueryLambdaVersionsResponse
 
 	q := rc.QueryLambdasApi.ListQueryLambdaVersions(ctx, workspace, name)
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Execute()
-		return err
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -315,12 +341,14 @@ func (rc *RockClient) ListQueryLambdaVersions(ctx context.Context,
 func (rc *RockClient) ListQueryLambdaTags(ctx context.Context, workspace,
 	queryLambda string) ([]openapi.QueryLambdaTag, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.ListQueryLambdaTagsResponse
 
 	q := rc.QueryLambdasApi.ListQueryLambdaTags(ctx, workspace, queryLambda)
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Execute()
-		return err
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {

--- a/retry.go
+++ b/retry.go
@@ -24,7 +24,7 @@ type Retrier interface {
 	RetryWithCheck(ctx context.Context, checkFunc RetryCheck) error
 }
 
-// RetryableError is an error which can be retried
+// RetryableError is an error which can be retried if Retryable() returns true.
 type RetryableError interface {
 	error
 	Retryable() bool
@@ -89,12 +89,6 @@ func (r ExponentialRetry) Retry(ctx context.Context, retryFn RetryFunc) error {
 		// no error, so no need to retry
 		if err == nil {
 			return nil
-		}
-
-		// if it already isn't a RetryableError, wrap the error so the caller can determine if it is a retryable error
-		var re RetryableError
-		if !errors.As(err, &re) {
-			err = NewError(err)
 		}
 
 		if !checkFn(err) {

--- a/retry_test.go
+++ b/retry_test.go
@@ -19,7 +19,7 @@ func fakeError(code int) error {
 		ErrorModel: &openapi.ErrorModel{
 			Type: &t,
 		},
-		Cause: errors.New(http.StatusText(code)),
+		StatusCode: code,
 	}
 }
 

--- a/roles.go
+++ b/roles.go
@@ -2,6 +2,7 @@ package rockset
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
@@ -19,6 +20,7 @@ const (
 func (rc *RockClient) CreateRole(ctx context.Context, roleName string,
 	options ...option.RoleOption) (openapi.Role, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.RoleResponse
 
 	createReq := rc.CustomRolesApi.CreateRole(ctx)
@@ -39,8 +41,9 @@ func (rc *RockClient) CreateRole(ctx context.Context, roleName string,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = createReq.Body(*b).Execute()
-		return err
+		resp, httpResp, err = createReq.Body(*b).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -56,6 +59,7 @@ func (rc *RockClient) CreateRole(ctx context.Context, roleName string,
 func (rc *RockClient) UpdateRole(ctx context.Context, roleName string,
 	options ...option.RoleOption) (openapi.Role, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.RoleResponse
 
 	createReq := rc.CustomRolesApi.UpdateRole(ctx, roleName)
@@ -74,8 +78,9 @@ func (rc *RockClient) UpdateRole(ctx context.Context, roleName string,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = createReq.Body(*b).Execute()
-		return err
+		resp, httpResp, err = createReq.Body(*b).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -90,12 +95,14 @@ func (rc *RockClient) UpdateRole(ctx context.Context, roleName string,
 // REST API documentation https://docs.rockset.com/rest-api/#deleterole
 func (rc *RockClient) DeleteRole(ctx context.Context, roleName string) error {
 	var err error
+	var httpResp *http.Response
 
 	getReq := rc.CustomRolesApi.DeleteRole(ctx, roleName)
 
 	err = rc.Retry(ctx, func() error {
-		_, _, err = getReq.Execute()
-		return err
+		_, httpResp, err = getReq.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -110,13 +117,15 @@ func (rc *RockClient) DeleteRole(ctx context.Context, roleName string) error {
 // REST API documentation https://docs.rockset.com/rest-api/#getrole
 func (rc *RockClient) GetRole(ctx context.Context, roleName string) (openapi.Role, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.RoleResponse
 
 	getReq := rc.CustomRolesApi.GetRole(ctx, roleName)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = getReq.Execute()
-		return err
+		resp, httpResp, err = getReq.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -131,13 +140,15 @@ func (rc *RockClient) GetRole(ctx context.Context, roleName string) (openapi.Rol
 // REST API documentation https://docs.rockset.com/rest-api/#listroles
 func (rc *RockClient) ListRoles(ctx context.Context) ([]openapi.Role, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.ListRolesResponse
 
 	getReq := rc.CustomRolesApi.ListRoles(ctx)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = getReq.Execute()
-		return err
+		resp, httpResp, err = getReq.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {

--- a/users.go
+++ b/users.go
@@ -3,6 +3,7 @@ package rockset
 import (
 	"context"
 	"github.com/rockset/rockset-go-client/option"
+	"net/http"
 
 	"github.com/rockset/rockset-go-client/openapi"
 )
@@ -14,14 +15,16 @@ import (
 // REST API documentation https://docs.rockset.com/rest-api/#createuser
 func (rc *RockClient) CreateUser(ctx context.Context, email string, roles []string) (openapi.User, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateUserResponse
 
 	q := rc.UsersApi.CreateUser(ctx)
 	req := openapi.NewCreateUserRequest(email, roles)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -38,6 +41,7 @@ func (rc *RockClient) CreateUser(ctx context.Context, email string, roles []stri
 func (rc *RockClient) UpdateUser(ctx context.Context, email string, roles []string,
 	options ...option.UserOption) (openapi.User, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.User
 
 	q := rc.UsersApi.UpdateUser(ctx, email)
@@ -58,8 +62,9 @@ func (rc *RockClient) UpdateUser(ctx context.Context, email string, roles []stri
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -74,12 +79,14 @@ func (rc *RockClient) UpdateUser(ctx context.Context, email string, roles []stri
 // REST API documentation https://docs.rockset.com/rest-api/#deleteuser
 func (rc *RockClient) DeleteUser(ctx context.Context, email string) error {
 	var err error
+	var httpResp *http.Response
 
 	q := rc.UsersApi.DeleteUser(ctx, email)
 
 	err = rc.Retry(ctx, func() error {
-		_, _, err = q.Execute()
-		return err
+		_, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -94,13 +101,15 @@ func (rc *RockClient) DeleteUser(ctx context.Context, email string) error {
 // REST API documentation https://docs.rockset.com/rest-api/#getcurrentuser
 func (rc *RockClient) GetCurrentUser(ctx context.Context) (openapi.User, error) {
 	var err error
+	var httpResp *http.Response
 	var user *openapi.User
 
 	q := rc.UsersApi.GetCurrentUser(ctx)
 
 	err = rc.Retry(ctx, func() error {
-		user, _, err = q.Execute()
-		return err
+		user, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -115,13 +124,15 @@ func (rc *RockClient) GetCurrentUser(ctx context.Context) (openapi.User, error) 
 // REST API documentation https://docs.rockset.com/rest-api/#getuser
 func (rc *RockClient) GetUser(ctx context.Context, email string) (openapi.User, error) {
 	var err error
+	var httpResp *http.Response
 	var user *openapi.User
 
 	q := rc.UsersApi.GetUser(ctx, email)
 
 	err = rc.Retry(ctx, func() error {
-		user, _, err = q.Execute()
-		return err
+		user, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -136,13 +147,15 @@ func (rc *RockClient) GetUser(ctx context.Context, email string) (openapi.User, 
 // REST API documentation https://docs.rockset.com/rest-api/#listusers
 func (rc *RockClient) ListUsers(ctx context.Context) ([]openapi.User, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.ListUsersResponse
 
 	q := rc.UsersApi.ListUsers(ctx)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Execute()
-		return err
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {

--- a/views.go
+++ b/views.go
@@ -16,8 +16,8 @@ import (
 func (rc *RockClient) CreateView(ctx context.Context, workspace, view, query string,
 	options ...option.ViewOption) (openapi.View, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateViewResponse
-	var hr *http.Response
 
 	q := rc.ViewsApi.CreateView(ctx, workspace)
 	req := openapi.NewCreateViewRequest(view, query)
@@ -32,8 +32,9 @@ func (rc *RockClient) CreateView(ctx context.Context, workspace, view, query str
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, hr, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -41,7 +42,7 @@ func (rc *RockClient) CreateView(ctx context.Context, workspace, view, query str
 	}
 
 	log := zerolog.Ctx(ctx)
-	log.Trace().Str("status", hr.Status).Str("state", resp.Data.GetState()).Msg("view created")
+	log.Trace().Str("status", httpResp.Status).Str("state", resp.Data.GetState()).Msg("view created")
 
 	return resp.GetData(), nil
 }
@@ -52,8 +53,8 @@ func (rc *RockClient) CreateView(ctx context.Context, workspace, view, query str
 func (rc *RockClient) UpdateView(ctx context.Context, workspace, view, query string,
 	options ...option.ViewOption) (openapi.View, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.UpdateViewResponse
-	var hr *http.Response
 
 	q := rc.ViewsApi.UpdateView(ctx, workspace, view)
 	req := openapi.NewUpdateViewRequest(query)
@@ -68,8 +69,9 @@ func (rc *RockClient) UpdateView(ctx context.Context, workspace, view, query str
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, hr, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -77,7 +79,7 @@ func (rc *RockClient) UpdateView(ctx context.Context, workspace, view, query str
 	}
 
 	log := zerolog.Ctx(ctx)
-	log.Trace().Str("status", hr.Status).Msg("view updated")
+	log.Trace().Str("status", httpResp.Status).Msg("view updated")
 
 	return resp.GetData(), nil
 }
@@ -88,13 +90,14 @@ func (rc *RockClient) UpdateView(ctx context.Context, workspace, view, query str
 // REST API documentation https://docs.rockset.com/rest-api/#deleteview
 func (rc *RockClient) DeleteView(ctx context.Context, workspace, view string) error {
 	var err error
-	var hr *http.Response
+	var httpResp *http.Response
 
 	q := rc.ViewsApi.DeleteView(ctx, workspace, view)
 
 	err = rc.Retry(ctx, func() error {
-		_, hr, err = q.Execute()
-		return err
+		_, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -102,7 +105,7 @@ func (rc *RockClient) DeleteView(ctx context.Context, workspace, view string) er
 	}
 
 	log := zerolog.Ctx(ctx)
-	log.Trace().Str("status", hr.Status).Msg("view deleted")
+	log.Trace().Str("status", httpResp.Status).Msg("view deleted")
 
 	return nil
 }
@@ -112,6 +115,7 @@ func (rc *RockClient) DeleteView(ctx context.Context, workspace, view string) er
 // REST API documentation https://docs.rockset.com/rest-api/#listviews
 func (rc *RockClient) ListViews(ctx context.Context, options ...option.ListViewOption) ([]openapi.View, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.ListViewsResponse
 
 	opts := option.ListViewOptions{}
@@ -123,15 +127,17 @@ func (rc *RockClient) ListViews(ctx context.Context, options ...option.ListViewO
 		q := rc.ViewsApi.ListViews(ctx)
 
 		err = rc.Retry(ctx, func() error {
-			resp, _, err = q.Execute()
-			return err
+			resp, httpResp, err = q.Execute()
+
+			return NewErrorWithStatusCode(err, httpResp.StatusCode)
 		})
 	} else {
 		q := rc.ViewsApi.WorkspaceViews(ctx, opts.Workspace)
 
 		err = rc.Retry(ctx, func() error {
-			resp, _, err = q.Execute()
-			return err
+			resp, httpResp, err = q.Execute()
+
+			return NewErrorWithStatusCode(err, httpResp.StatusCode)
 		})
 	}
 
@@ -149,14 +155,16 @@ func (rc *RockClient) ListViews(ctx context.Context, options ...option.ListViewO
 // REST API documentation https://docs.rockset.com/rest-api/#getview
 func (rc *RockClient) GetView(ctx context.Context, workspace, name string) (openapi.View, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.GetViewResponse
 	log := zerolog.Ctx(ctx)
 
 	q := rc.ViewsApi.GetView(ctx, workspace, name)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Execute()
-		return err
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {

--- a/virtual_instances.go
+++ b/virtual_instances.go
@@ -2,6 +2,7 @@ package rockset
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
@@ -14,13 +15,15 @@ import (
 // REST API documentation https://docs.rockset.com/rest-api/#getvirtualinstance
 func (rc *RockClient) GetVirtualInstance(ctx context.Context, vID string) (openapi.VirtualInstance, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.GetVirtualInstanceResponse
 
 	q := rc.VirtualInstancesApi.GetVirtualInstance(ctx, vID)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Execute()
-		return err
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -35,13 +38,15 @@ func (rc *RockClient) GetVirtualInstance(ctx context.Context, vID string) (opena
 // REST API documentation https://docs.rockset.com/rest-api/#listvirtualinstances
 func (rc *RockClient) ListVirtualInstances(ctx context.Context) ([]openapi.VirtualInstance, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.ListVirtualInstancesResponse
 
 	q := rc.VirtualInstancesApi.ListVirtualInstances(ctx)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Execute()
-		return err
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -57,6 +62,7 @@ func (rc *RockClient) ListVirtualInstances(ctx context.Context) ([]openapi.Virtu
 func (rc *RockClient) UpdateVirtualInstance(ctx context.Context, vID string,
 	options ...option.VirtualInstanceOption) (openapi.VirtualInstance, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.UpdateVirtualInstanceResponse
 
 	opts := option.VirtualInstanceOptions{}
@@ -75,8 +81,9 @@ func (rc *RockClient) UpdateVirtualInstance(ctx context.Context, vID string,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Execute()
-		return err
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {

--- a/wait_test.go
+++ b/wait_test.go
@@ -29,8 +29,7 @@ func (s *WaitTestSuite) TestResourceIsAvailable() {
 
 		switch counter {
 		case 0:
-			t := statusWithoutSpace(http.StatusNotFound)
-			return Error{ErrorModel: &openapi.ErrorModel{Type: &t}, Cause: fmt.Errorf("resource not present")}
+			return Error{ErrorModel: &openapi.ErrorModel{}, StatusCode: http.StatusNotFound, Cause: fmt.Errorf("resource not present")}
 		case 1:
 			return nil
 		default:
@@ -62,8 +61,7 @@ func (s *WaitTestSuite) TestResourceIsGone() {
 		case 0:
 			return nil
 		case 1:
-			t := statusWithoutSpace(http.StatusNotFound)
-			return Error{ErrorModel: &openapi.ErrorModel{Type: &t}, Cause: fmt.Errorf("resource not present")}
+			return Error{ErrorModel: &openapi.ErrorModel{}, StatusCode: http.StatusNotFound, Cause: fmt.Errorf("resource not present")}
 		default:
 			return fmt.Errorf("fail")
 		}

--- a/workspaces.go
+++ b/workspaces.go
@@ -2,6 +2,7 @@ package rockset
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/rs/zerolog"
 
@@ -15,6 +16,7 @@ import (
 func (rc *RockClient) CreateWorkspace(ctx context.Context, workspace string,
 	options ...option.WorkspaceOption) (openapi.Workspace, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.CreateWorkspaceResponse
 
 	q := rc.WorkspacesApi.CreateWorkspace(ctx)
@@ -30,8 +32,9 @@ func (rc *RockClient) CreateWorkspace(ctx context.Context, workspace string,
 	}
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Body(*req).Execute()
-		return err
+		resp, httpResp, err = q.Body(*req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -46,14 +49,16 @@ func (rc *RockClient) CreateWorkspace(ctx context.Context, workspace string,
 // REST API documentation https://docs.rockset.com/rest-api/#getworkspace
 func (rc *RockClient) GetWorkspace(ctx context.Context, workspace string) (openapi.Workspace, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.GetWorkspaceResponse
 	log := zerolog.Ctx(ctx)
 
 	q := rc.WorkspacesApi.GetWorkspace(ctx, workspace)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Execute()
-		return err
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -71,13 +76,15 @@ func (rc *RockClient) GetWorkspace(ctx context.Context, workspace string) (opena
 // REST API documentation https://docs.rockset.com/rest-api/#listworkspaces
 func (rc *RockClient) ListWorkspaces(ctx context.Context) ([]openapi.Workspace, error) {
 	var err error
+	var httpResp *http.Response
 	var resp *openapi.ListWorkspacesResponse
 
 	q := rc.WorkspacesApi.ListWorkspaces(ctx)
 
 	err = rc.Retry(ctx, func() error {
-		resp, _, err = q.Execute()
-		return err
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {
@@ -92,12 +99,14 @@ func (rc *RockClient) ListWorkspaces(ctx context.Context) ([]openapi.Workspace, 
 // REST API documentation https://docs.rockset.com/rest-api/#deleteworkspace
 func (rc *RockClient) DeleteWorkspace(ctx context.Context, name string) error {
 	var err error
+	var httpResp *http.Response
 
 	q := rc.WorkspacesApi.DeleteWorkspace(ctx, name)
 
 	err = rc.Retry(ctx, func() error {
-		_, _, err = q.Execute()
-		return err
+		_, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp.StatusCode)
 	})
 
 	if err != nil {


### PR DESCRIPTION
This includes a `StatusCode` field in the error, so we can use a proper way to check if the error should be retried. All convenience methods are returning this now, so the `DefaultRetryableErrorCheck()` should work for all calls.