### PR TITLE
multi-vi support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,10 @@ jobs:
     steps:
       - checkout
       - run: go install github.com/mattn/goveralls@latest
-      - run: go test -v -cover -timeout 20m -race -coverprofile=cover.out ./...
+      - run:
+          name: go test
+          no_output_timeout: 30m
+          command: go test -v -cover -timeout 30m -race -coverprofile=cover.out ./...
       - run: goveralls -coverprofile=cover.out -service=circle-ci
   release:
     docker:

--- a/option/query.go
+++ b/option/query.go
@@ -4,9 +4,18 @@ import "github.com/rockset/rockset-go-client/openapi"
 
 type QueryOption func(request *openapi.QueryRequest)
 
+// WithWarnings enables warnings. Warnings can help debug query issues but negatively affect performance.
 func WithWarnings() QueryOption {
 	return func(o *openapi.QueryRequest) {
 		o.Sql.GenerateWarnings = openapi.PtrBool(true)
+	}
+}
+
+// WithPaginationDocCount sets the number of documents to return in addition to paginating for
+// this query call. Only relevant if WithPagination is also set.
+func WithPaginationDocCount(limit int32) QueryOption {
+	return func(o *openapi.QueryRequest) {
+		o.Sql.InitialPaginateResponseDocCount = &limit
 	}
 }
 
@@ -15,6 +24,8 @@ func WithRowLimit(limit int32) QueryOption {
 		o.Sql.DefaultRowLimit = &limit
 	}
 }
+
+// TODO add WithVirtualInstance for the regular query api and make it use rockset.ExecuteQueryOnVirtualInstance
 
 func WithParameter(name, valueType, value string) QueryOption {
 	return func(o *openapi.QueryRequest) {

--- a/option/query_lambda.go
+++ b/option/query_lambda.go
@@ -22,19 +22,22 @@ func WithVersion(version string) QueryLambdaOption {
 	}
 }
 
-func WithRowLimit2(limit int32) QueryLambdaOption {
+// WithQueryLambdaRowLimit sets the maximum number of rows to retrieve.
+func WithQueryLambdaRowLimit(limit int32) QueryLambdaOption {
 	return func(o *ExecuteQueryLambdaRequest) {
 		o.DefaultRowLimit = &limit
 	}
 }
 
-func WithWarnings2() QueryLambdaOption {
+// WithQueryLambdaWarnings enables warnings.
+func WithQueryLambdaWarnings() QueryLambdaOption {
 	return func(o *ExecuteQueryLambdaRequest) {
 		o.GenerateWarnings = openapi.PtrBool(true)
 	}
 }
 
-func WithParameter2(name, valueType, value string) QueryLambdaOption {
+// WithQueryLambdaParameter sets a query lambda parameter.
+func WithQueryLambdaParameter(name, valueType, value string) QueryLambdaOption {
 	return func(o *ExecuteQueryLambdaRequest) {
 		o.Parameters = append(o.Parameters, openapi.QueryParameter{
 			Name:  name,

--- a/option/virtual_instance.go
+++ b/option/virtual_instance.go
@@ -1,25 +1,55 @@
 package option
 
+import "time"
+
 // VirtualInstanceOptions contains the optional settings for a virtual instance.
 type VirtualInstanceOptions struct {
-	MonitoringEnabled *bool
-	Size              *string
+	Description          *string
+	MonitoringEnabled    *bool
+	Size                 *string
+	MountRefreshInterval *time.Duration
+	AutoSuspend          *time.Duration
 }
 
 type VirtualInstanceOption func(*VirtualInstanceOptions)
 
-// WithVIMonitoring is used to optionally set the virtual instance monitoring.
+// WithVIMonitoring is used to optionally set the virtual instance monitoring, which can only be done
+// when updating the instance, not during creation.
 func WithVIMonitoring(enabled bool) VirtualInstanceOption {
 	return func(o *VirtualInstanceOptions) {
 		o.MonitoringEnabled = &enabled
 	}
 }
 
-// WithVISize is used to optionally set the virtual instance size.
-func WithVISize(size VirtualInstanceSize) VirtualInstanceOption {
+// WithMountRefreshInterval is used to optionally set the mount refresh interval. Setting it to 0 means
+// it will be a continuous refresh, but then WithContinuousMountRefresh should be used instead. Not specifying
+// a mount refresh interval will make it never refresh, and should only be used for static collections.
+func WithMountRefreshInterval(interval time.Duration) VirtualInstanceOption {
 	return func(o *VirtualInstanceOptions) {
-		s := size.String()
-		o.Size = &s
+		o.MountRefreshInterval = &interval
+	}
+}
+
+// WithContinuousMountRefresh is used to set the mount refresh interval to a continuous refresh.
+func WithContinuousMountRefresh() VirtualInstanceOption {
+	return func(o *VirtualInstanceOptions) {
+		var zero time.Duration
+		o.MountRefreshInterval = &zero
+	}
+}
+
+// WithAutoSuspend duration without queries after which the virtual instance is suspended. Minimum time is 15 minutes.
+func WithAutoSuspend(d time.Duration) VirtualInstanceOption {
+	return func(o *VirtualInstanceOptions) {
+		o.AutoSuspend = &d
+	}
+}
+
+// WithVirtualInstanceSize is used to optionally set the virtual instance size.
+func WithVirtualInstanceSize(size VirtualInstanceSize) VirtualInstanceOption {
+	return func(o *VirtualInstanceOptions) {
+		t := size.String()
+		o.Size = &t
 	}
 }
 
@@ -33,14 +63,16 @@ func (t VirtualInstanceSize) String() string {
 }
 
 const (
-	FreeSize     VirtualInstanceSize = "FREE"
-	SharedSize   VirtualInstanceSize = "SHARED"
-	SmallSize    VirtualInstanceSize = "SMALL"
-	MediumSize   VirtualInstanceSize = "MEDIUM"
-	LargeSize    VirtualInstanceSize = "LARGE"
-	XLargeSize   VirtualInstanceSize = "XLARGE"
-	XLarge2Size  VirtualInstanceSize = "XLARGE2"
-	XLarge4Size  VirtualInstanceSize = "XLARGE4"
-	XLarge8Size  VirtualInstanceSize = "XLARGE8"
-	XLarge16Size VirtualInstanceSize = "XLARGE16"
+	SizeFree     VirtualInstanceSize = "FREE"
+	SizeNano     VirtualInstanceSize = "NANO"
+	SizeShared   VirtualInstanceSize = "SHARED"
+	SizeMilli    VirtualInstanceSize = "MILLI"
+	SizeSmall    VirtualInstanceSize = "SMALL"
+	SizeMedium   VirtualInstanceSize = "MEDIUM"
+	SizeLarge    VirtualInstanceSize = "LARGE"
+	SizeXLarge   VirtualInstanceSize = "XLARGE"
+	SizeXLarge2  VirtualInstanceSize = "XLARGE2"
+	SizeXLarge4  VirtualInstanceSize = "XLARGE4"
+	SizeXLarge8  VirtualInstanceSize = "XLARGE8"
+	SizeXLarge16 VirtualInstanceSize = "XLARGE16"
 )

--- a/queries.go
+++ b/queries.go
@@ -25,16 +25,16 @@ func (rc *RockClient) Query(ctx context.Context, sql string,
 	var response *openapi.QueryResponse
 
 	q := rc.QueriesApi.Query(ctx)
-	rq := openapi.NewQueryRequestWithDefaults()
-	rq.Sql = openapi.QueryRequestSql{Query: sql}
-	rq.Sql.Parameters = []openapi.QueryParameter{}
+	queryRequest := openapi.NewQueryRequestWithDefaults()
+	queryRequest.Sql = openapi.QueryRequestSql{Query: sql}
+	queryRequest.Sql.Parameters = []openapi.QueryParameter{}
 
 	for _, o := range options {
-		o(rq)
+		o(queryRequest)
 	}
 
 	err = rc.Retry(ctx, func() error {
-		response, httpResp, err = q.Body(*rq).Execute()
+		response, httpResp, err = q.Body(*queryRequest).Execute()
 
 		return NewErrorWithStatusCode(err, httpResp)
 	})

--- a/rockset_test.go
+++ b/rockset_test.go
@@ -63,6 +63,12 @@ func testClient(t *testing.T) *rockset.RockClient {
 	return rc
 }
 
+func debugClient(t *testing.T) *rockset.RockClient {
+	rc, err := rockset.NewClient(rockset.WithUserAgent("rockset-go-integration-tests"), rockset.WithHTTPDebug())
+	require.NoError(t, err)
+	return rc
+}
+
 // these are used for testing when a persistent value is needed
 const buildNum = "CIRCLE_BUILD_NUM"
 const persistentWorkspace = "persistent"

--- a/virtual_instances.go
+++ b/virtual_instances.go
@@ -2,6 +2,7 @@ package rockset
 
 import (
 	"context"
+	"github.com/rs/zerolog"
 	"net/http"
 
 	"github.com/rockset/rockset-go-client/openapi"
@@ -9,6 +10,92 @@ import (
 )
 
 // https://docs.rockset.com/rest-api/#virtual-instances
+
+const (
+	VirtualInstanceInitializing           = "INITIALIZING"
+	VirtualInstanceProvisioningResources  = "PROVISIONING_RESOURCES"
+	VirtualInstanceRebalancingCollections = "REBALANCING_COLLECTIONS"
+	VirtualInstanceActive                 = "ACTIVE"
+	VirtualInstanceSuspending             = "SUSPENDING"
+	VirtualInstanceSuspended              = "SUSPENDED"
+	VirtualInstanceResuming               = "RESUMING"
+	VirtualInstanceDeleted                = "DELETED"
+)
+
+// CreateVirtualInstance creates a new virtual instance.
+// Note that not supplying option.WithMountRefreshInterval() or option.WithContinuousMountRefresh() will
+// create a virtual instance that will never refresh the mounts.
+//
+// REST API documentation https://rockset.com/docs/rest-api/#createvirtualinstance
+func (rc *RockClient) CreateVirtualInstance(ctx context.Context, name string, options ...option.VirtualInstanceOption) (openapi.VirtualInstance, error) {
+	var err error
+	var httpResp *http.Response
+	var resp *openapi.CreateVirtualInstanceResponse
+
+	opts := option.VirtualInstanceOptions{}
+	for _, o := range options {
+		o(&opts)
+	}
+
+	zl := zerolog.Ctx(ctx)
+	req := openapi.CreateVirtualInstanceRequest{Name: name}
+	if opts.Description != nil {
+		req.Description = opts.Description
+	}
+	if opts.Size != nil {
+		req.Type = opts.Size
+	}
+	if opts.AutoSuspend != nil {
+		s := int32(opts.AutoSuspend.Seconds())
+		zl.Info().Int32("s", s).Dur("d", *opts.AutoSuspend).Msg("auto suspend")
+		req.AutoSuspendSeconds = &s
+	}
+	if opts.MountRefreshInterval != nil {
+		s := int32(opts.MountRefreshInterval.Seconds())
+		req.MountRefreshIntervalSeconds = &s
+	}
+	if opts.MonitoringEnabled != nil {
+		log := zerolog.Ctx(ctx)
+		log.Warn().Msg("monitoring can't be enabled on virtual instance creation")
+	}
+
+	q := rc.VirtualInstancesApi.CreateVirtualInstance(ctx)
+
+	err = rc.Retry(ctx, func() error {
+		resp, httpResp, err = q.Body(req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp)
+	})
+
+	if err != nil {
+		return openapi.VirtualInstance{}, err
+	}
+
+	return resp.GetData(), nil
+}
+
+// DeleteVirtualInstance deletes a virtual instance.
+//
+// REST API documentation https://rockset.com/docs/rest-api/#deletevirtualinstance
+func (rc *RockClient) DeleteVirtualInstance(ctx context.Context, vID string) (openapi.VirtualInstance, error) {
+	var err error
+	var httpResp *http.Response
+	var resp *openapi.DeleteVirtualInstanceResponse
+
+	q := rc.VirtualInstancesApi.DeleteVirtualInstance(ctx, vID)
+
+	err = rc.Retry(ctx, func() error {
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp)
+	})
+
+	if err != nil {
+		return openapi.VirtualInstance{}, err
+	}
+
+	return resp.GetData(), nil
+}
 
 // GetVirtualInstance gets a virtual instance by the virtual instance uuid.
 //
@@ -91,4 +178,199 @@ func (rc *RockClient) UpdateVirtualInstance(ctx context.Context, vID string,
 	}
 
 	return resp.GetData(), nil
+}
+
+// SuspendVirtualInstance suspends a virtual instance.
+//
+// REST API documentation https://docs.rockset.com/rest-api/#suspendvirtualinstance
+func (rc *RockClient) SuspendVirtualInstance(ctx context.Context, vID string) (openapi.VirtualInstance, error) {
+	var err error
+	var httpResp *http.Response
+	var resp *openapi.SuspendVirtualInstanceResponse
+
+	q := rc.VirtualInstancesApi.SuspendVirtualInstance(ctx, vID)
+
+	err = rc.Retry(ctx, func() error {
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp)
+	})
+
+	if err != nil {
+		return openapi.VirtualInstance{}, err
+	}
+
+	return resp.GetData(), nil
+}
+
+// ResumeVirtualInstance resumes a virtual instance.
+//
+// REST API documentation https://docs.rockset.com/rest-api/#resumevirtualinstance
+func (rc *RockClient) ResumeVirtualInstance(ctx context.Context, vID string) (openapi.VirtualInstance, error) {
+	var err error
+	var httpResp *http.Response
+	var resp *openapi.ResumeVirtualInstanceResponse
+
+	q := rc.VirtualInstancesApi.ResumeVirtualInstance(ctx, vID)
+
+	err = rc.Retry(ctx, func() error {
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp)
+	})
+
+	if err != nil {
+		return openapi.VirtualInstance{}, err
+	}
+
+	return resp.GetData(), nil
+}
+
+// ExecuteQueryOnVirtualInstance executes the SQL query on a specific virtual instance instead of the main virtual instance.
+//
+// REST API documentation https://rockset.com/docs/rest-api/#queryvirtualinstance
+func (rc *RockClient) ExecuteQueryOnVirtualInstance(ctx context.Context, vID string, sql string, options ...option.QueryOption) (openapi.QueryResponse, error) {
+	var err error
+	var httpResp *http.Response
+	var resp *openapi.QueryResponse
+
+	queryRequest := openapi.NewQueryRequestWithDefaults()
+	queryRequest.Sql = openapi.QueryRequestSql{Query: sql}
+	queryRequest.Sql.Parameters = []openapi.QueryParameter{}
+
+	for _, o := range options {
+		o(queryRequest)
+	}
+
+	q := rc.VirtualInstancesApi.QueryVirtualInstance(ctx, vID)
+
+	err = rc.Retry(ctx, func() error {
+		resp, httpResp, err = q.Body(*queryRequest).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp)
+	})
+
+	if err != nil {
+		return openapi.QueryResponse{}, err
+	}
+
+	return *resp, nil
+}
+
+// GetVirtualInstanceQueries lists actively queued and running queries for a particular Virtual Instance.
+//
+// REST API documentation
+func (rc *RockClient) GetVirtualInstanceQueries(ctx context.Context, vID string) ([]openapi.QueryInfo, error) {
+	var err error
+	var httpResp *http.Response
+	var resp *openapi.ListQueriesResponse
+
+	q := rc.VirtualInstancesApi.GetVirtualInstanceQueries(ctx, vID)
+
+	err = rc.Retry(ctx, func() error {
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Data, nil
+}
+
+// ListCollectionMounts lists collection mounts for a particular virtual instance.
+//
+// REST API documentation https://rockset.com/docs/rest-api/#listcollectionmounts
+func (rc *RockClient) ListCollectionMounts(ctx context.Context, vID string) ([]openapi.CollectionMount, error) {
+	var err error
+	var httpResp *http.Response
+	var resp *openapi.ListCollectionMountsResponse
+
+	q := rc.VirtualInstancesApi.ListCollectionMounts(ctx, vID)
+
+	err = rc.Retry(ctx, func() error {
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Data, nil
+}
+
+// GetCollectionMount gets a mount on this virtual instance.
+//
+// REST API documentation https://rockset.com/docs/rest-api/#getcollectionmount
+func (rc *RockClient) GetCollectionMount(ctx context.Context, vID, collectionPath string) (openapi.CollectionMount, error) {
+	var err error
+	var httpResp *http.Response
+	var resp *openapi.CollectionMountResponse
+
+	q := rc.VirtualInstancesApi.GetCollectionMount(ctx, vID, collectionPath)
+
+	err = rc.Retry(ctx, func() error {
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp)
+	})
+
+	if err != nil {
+		return openapi.CollectionMount{}, err
+	}
+
+	return *resp.Data, nil
+}
+
+// MountCollection mounts collections on a virtual instance.
+//
+// REST API documentation https://rockset.com/docs/rest-api/#mountcollection
+func (rc *RockClient) MountCollection(ctx context.Context, vID string, collectionPaths []string) ([]openapi.CollectionMount, error) {
+	var err error
+	var httpResp *http.Response
+	var resp *openapi.CreateCollectionMountsResponse
+
+	q := rc.VirtualInstancesApi.MountCollection(ctx, vID)
+	req := openapi.CreateCollectionMountRequest{
+		CollectionPaths: collectionPaths,
+	}
+
+	err = rc.Retry(ctx, func() error {
+		resp, httpResp, err = q.Body(req).Execute()
+
+		return NewErrorWithStatusCode(err, httpResp)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Data, nil
+}
+
+// UnmountCollection unmount a collection from a virtual instance.
+//
+// REST API documentation https://rockset.com/docs/rest-api/#unmountcollection
+func (rc *RockClient) UnmountCollection(ctx context.Context, vID string, collectionPath string) (openapi.CollectionMount, error) {
+	var err error
+	var httpResp *http.Response
+	var resp *openapi.CollectionMountResponse
+
+	q := rc.VirtualInstancesApi.UnmountCollection(ctx, vID, collectionPath)
+
+	err = rc.Retry(ctx, func() error {
+		resp, httpResp, err = q.Execute()
+
+		return NewErrorWithStatusCode(err, httpResp)
+	})
+
+	if err != nil {
+		return openapi.CollectionMount{}, err
+	}
+
+	return *resp.Data, nil
 }

--- a/virtual_instances_test.go
+++ b/virtual_instances_test.go
@@ -1,25 +1,201 @@
 package rockset_test
 
 import (
+	"fmt"
+	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/dataset"
+	"github.com/rockset/rockset-go-client/option"
+	"github.com/stretchr/testify/suite"
+	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"time"
 )
 
-func TestRockClient_ListVirtualInstances(t *testing.T) {
+const (
+	rocksetCircleCIMainVI = "rrn:vi:usw2a1:29e4a43c-fff4-4fe6-80e3-1ee57bc22e82"
+	rocksetTestMainVI     = "rrn:vi:usw2a1:b0f23396-a8c9-45c5-9452-00c1267094a4"
+)
+
+type VirtualInstanceSuite struct {
+	suite.Suite
+	rc  *rockset.RockClient
+	vID string
+}
+
+func TestVirtualInstance(t *testing.T) {
 	skipUnlessIntegrationTest(t)
 
-	ctx := testCtx()
-	rc := testClient(t)
-
-	vis, err := rc.ListVirtualInstances(ctx)
-	require.NoError(t, err)
-	assert.NotEmpty(t, vis)
-
-	for _, vi := range vis {
-		t.Logf("vi %s: %s %s", vi.GetId(), vi.GetState(), vi.GetCurrentSize())
-		assert.Equal(t, "SMALL", vi.GetCurrentSize())
-		assert.Equal(t, "SMALL", vi.GetDesiredSize())
+	s := VirtualInstanceSuite{
+		rc:  testClient(t),
+		vID: rocksetCircleCIMainVI,
 	}
+	suite.Run(t, &s)
+}
+
+func (s *VirtualInstanceSuite) TestListQueries() {
+	ctx := testCtx()
+
+	queries, err := s.rc.GetVirtualInstanceQueries(ctx, s.vID)
+	s.Require().NoError(err)
+	for _, q := range queries {
+		s.T().Logf("%s: %s", q.GetQueryId(), q.GetStatus())
+	}
+}
+
+func (s *VirtualInstanceSuite) TestGetCollectionMount() {
+	ctx := testCtx()
+
+	mount, err := s.rc.GetCollectionMount(ctx, s.vID, "commons.movie_releases")
+	s.Require().NoError(err)
+	s.Assert().Equal(strings.TrimPrefix(s.vID, "rrn:vi:usw2a1:"), mount.GetVirtualInstanceId())
+}
+
+func (s *VirtualInstanceSuite) TestListCollectionMounts() {
+	ctx := testCtx()
+
+	mounts, err := s.rc.ListCollectionMounts(ctx, s.vID)
+	s.Require().NoError(err)
+	s.Assert().NotEmpty(mounts)
+}
+
+func (s *VirtualInstanceSuite) TestExecuteQuery() {
+	ctx := testCtx()
+
+	result, err := s.rc.ExecuteQueryOnVirtualInstance(ctx, s.vID,
+		"SELECT * from commons._events LIMIT 10",
+		option.WithWarnings())
+	s.Require().NoError(err)
+	s.Assert().Contains(result.Collections, "commons._events")
+}
+
+func (s *VirtualInstanceSuite) TestGetVirtualInstance() {
+	ctx := testCtx()
+
+	// make sure we can access the VI using both the plain id and the RRN
+	rocksetTestVIs := []string{
+		strings.TrimPrefix(s.vID, "rrn:vi:usw2a1:"),
+		s.vID,
+	}
+
+	for _, vi := range rocksetTestVIs {
+		s.Run(vi, func() {
+			main, err := s.rc.GetVirtualInstance(ctx, vi)
+			s.Assert().NoError(err)
+			s.Assert().Equal("main", main.GetName())
+		})
+	}
+}
+
+func (s *VirtualInstanceSuite) TestListVirtualInstances() {
+	ctx := testCtx()
+
+	vis, err := s.rc.ListVirtualInstances(ctx)
+	s.Require().NoError(err)
+	s.Assert().NotEmpty(vis)
+}
+
+type VirtualInstanceIntegrationSuite struct {
+	suite.Suite
+	rc         *rockset.RockClient
+	vID        string
+	name       string
+	workspace  string
+	collection string
+}
+
+// This test suite requires a Rockset org with "premium" support, as it needs to create a virtual instance.
+func TestVirtualInstanceIntegration(t *testing.T) {
+	skipUnlessIntegrationTest(t)
+	t.Log("This test can take more than 10 minutes to run, so make sure to use `go test -timeout 15m`")
+
+	s := VirtualInstanceIntegrationSuite{
+		rc:   testClient(t),
+		name: randomName("vi"),
+	}
+	suite.Run(t, &s)
+}
+
+func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance() {
+	ctx := testCtx()
+
+	vi, err := s.rc.CreateVirtualInstance(ctx, s.name, option.WithVirtualInstanceSize(option.SizeSmall),
+		option.WithContinuousMountRefresh(), option.WithAutoSuspend(time.Hour))
+	s.Require().NoError(err)
+	s.vID = vi.GetId()
+	s.T().Logf("vi %s is created", s.vID)
+
+	err = s.rc.WaitUntilVirtualInstanceActive(ctx, s.vID)
+	s.Require().NoError(err)
+	s.T().Logf("vi %s is active", s.vID)
+
+	ws, err := s.rc.CreateWorkspace(ctx, s.name)
+	s.Require().NoError(err)
+	s.workspace = ws.GetName()
+	s.T().Logf("workspace %s is created", s.workspace)
+
+	err = s.rc.WaitUntilWorkspaceAvailable(ctx, s.workspace)
+	s.Require().NoError(err)
+	s.T().Logf("workspace %s is available", s.workspace)
+
+	c, err := s.rc.CreateCollection(ctx, s.workspace, s.name, option.WithSampleDataset(dataset.Movies))
+	s.Require().NoError(err)
+	s.collection = c.GetName()
+	s.T().Logf("collection %s.%s is created", s.workspace, s.collection)
+
+	err = s.rc.WaitUntilCollectionHasDocuments(ctx, s.workspace, s.collection, 2_830)
+	s.Require().NoError(err)
+	s.T().Log("collection has documents")
+
+	path := s.workspace + "." + s.collection
+	_, err = s.rc.MountCollection(ctx, s.vID, []string{path})
+	s.Require().NoError(err)
+	s.T().Logf("collection %s.%s is mounted on %s", s.workspace, s.collection, s.vID)
+
+	err = s.rc.WaitUntilCollectionReady(ctx, s.workspace, s.collection)
+	s.Require().NoError(err)
+	s.T().Logf("collection %s.%s is ready", s.workspace, s.collection)
+
+	query := fmt.Sprintf("SELECT * FROM %s", path)
+	_, err = s.rc.Query(ctx, query)
+	s.Require().NoError(err)
+	s.T().Log("query ran")
+
+	_, err = s.rc.SuspendVirtualInstance(ctx, s.vID)
+	s.Require().NoError(err)
+	s.T().Log("vi is suspending")
+
+	err = s.rc.WaitUntilVirtualInstanceSuspended(ctx, s.vID)
+	s.Require().NoError(err)
+	s.T().Log("vi is suspended")
+
+	_, err = s.rc.ResumeVirtualInstance(ctx, s.vID)
+	s.Require().NoError(err)
+	s.T().Log("vi is resuming")
+
+	err = s.rc.WaitUntilVirtualInstanceActive(ctx, s.vID)
+	s.Require().NoError(err)
+	s.T().Log("vi is active")
+
+	_, err = s.rc.Query(ctx, query)
+	s.Require().NoError(err)
+	s.T().Log("query after resume ran")
+}
+
+func (s *VirtualInstanceIntegrationSuite) TearDownSuite() {
+	ctx := testCtx()
+
+	err := s.rc.DeleteCollection(ctx, s.workspace, s.collection)
+	s.Assert().NoError(err)
+
+	err = s.rc.WaitUntilCollectionGone(ctx, s.workspace, s.collection)
+	s.Assert().NoError(err)
+
+	err = s.rc.DeleteWorkspace(ctx, s.workspace)
+	s.Assert().NoError(err)
+
+	err = s.rc.WaitUntilWorkspaceGone(ctx, s.workspace)
+	s.Assert().NoError(err)
+
+	_, err = s.rc.DeleteVirtualInstance(ctx, s.vID)
+	s.Assert().NoError(err)
 }

--- a/workspaces_test.go
+++ b/workspaces_test.go
@@ -39,6 +39,8 @@ func (s *SuiteWorkspace) TearDownSuite() {
 	ctx := testCtx()
 	err := s.rc.DeleteWorkspace(ctx, s.ws)
 	s.Require().NoError(err)
+	err = s.rc.WaitUntilWorkspaceGone(ctx, s.ws)
+	s.Require().NoError(err)
 }
 
 func (s *SuiteWorkspace) TestGetWorkspace() {


### PR DESCRIPTION
Add support for using virtual instances

```
go test -timeout 20m -v -run TestVirtualInstanceIntegration
=== RUN   TestVirtualInstanceIntegration
    virtual_instances_test.go:103: This test can take more than 10 minutes to run, so make sure to use `go test -timeout 15m`
=== RUN   TestVirtualInstanceIntegration/TestVirtualInstance
    virtual_instances_test.go:119: vi c71a7179-1868-454d-93cb-ac811d4dc25e is created
    virtual_instances_test.go:123: vi c71a7179-1868-454d-93cb-ac811d4dc25e is active
    virtual_instances_test.go:128: workspace go_pme_vi_KExlKM is created
    virtual_instances_test.go:132: workspace go_pme_vi_KExlKM is available
    virtual_instances_test.go:137: collection go_pme_vi_KExlKM.go_pme_vi_KExlKM is created
    virtual_instances_test.go:141: collection has documents
    virtual_instances_test.go:146: collection go_pme_vi_KExlKM.go_pme_vi_KExlKM is mounted on c71a7179-1868-454d-93cb-ac811d4dc25e
    virtual_instances_test.go:150: collection go_pme_vi_KExlKM.go_pme_vi_KExlKM is ready
    virtual_instances_test.go:155: query ran
    virtual_instances_test.go:159: vi is suspending
    virtual_instances_test.go:163: vi is suspended
    virtual_instances_test.go:167: vi is resuming
    virtual_instances_test.go:171: vi is active
    virtual_instances_test.go:175: query after resume ran
--- PASS: TestVirtualInstanceIntegration (613.27s)
    --- PASS: TestVirtualInstanceIntegration/TestVirtualInstance (588.47s)
PASS
ok  	github.com/rockset/rockset-go-client	613.546s
```