### PR TITLE
[ORC-2439] Remove GenerateWarnings option from Go client

### DIFF
--- a/example_query_test.go
+++ b/example_query_test.go
@@ -23,7 +23,6 @@ func Example_queryRaw() {
 	rq := openapi.NewQueryRequestWithDefaults()
 
 	rq.Sql = openapi.QueryRequestSql{Query: "SELECT * FROM commons._events where label = :label"}
-	rq.Sql.GenerateWarnings = openapi.PtrBool(true)
 	rq.Sql.DefaultRowLimit = openapi.PtrInt32(10)
 
 	rq.Sql.Parameters = []openapi.QueryParameter{

--- a/example_query_test.go
+++ b/example_query_test.go
@@ -56,7 +56,7 @@ func ExampleRockClient_query() {
 	}
 
 	r, err := rc.Query(ctx, "SELECT * FROM commons._events where label = :label",
-		option.WithWarnings(), option.WithRowLimit(10),
+		option.WithRowLimit(10),
 		option.WithParameter("label", "string", "QUERY_SUCCESS"))
 	if err != nil {
 		log.Fatal(err)

--- a/option/query.go
+++ b/option/query.go
@@ -4,13 +4,6 @@ import "github.com/rockset/rockset-go-client/openapi"
 
 type QueryOption func(request *openapi.QueryRequest)
 
-// WithWarnings enables warnings. Warnings can help debug query issues but negatively affect performance.
-func WithWarnings() QueryOption {
-	return func(o *openapi.QueryRequest) {
-		o.Sql.GenerateWarnings = openapi.PtrBool(true)
-	}
-}
-
 func WithRowLimit(limit int32) QueryOption {
 	return func(o *openapi.QueryRequest) {
 		o.Sql.DefaultRowLimit = &limit

--- a/option/query_lambda.go
+++ b/option/query_lambda.go
@@ -29,13 +29,6 @@ func WithQueryLambdaRowLimit(limit int32) QueryLambdaOption {
 	}
 }
 
-// WithQueryLambdaWarnings enables warnings.
-func WithQueryLambdaWarnings() QueryLambdaOption {
-	return func(o *ExecuteQueryLambdaRequest) {
-		o.GenerateWarnings = openapi.PtrBool(true)
-	}
-}
-
 // WithQueryLambdaParameter sets a query lambda parameter.
 func WithQueryLambdaParameter(name, valueType, value string) QueryLambdaOption {
 	return func(o *ExecuteQueryLambdaRequest) {

--- a/virtual_instances_test.go
+++ b/virtual_instances_test.go
@@ -62,8 +62,7 @@ func (s *VirtualInstanceSuite) TestExecuteQuery() {
 	ctx := testCtx()
 
 	result, err := s.rc.ExecuteQueryOnVirtualInstance(ctx, s.vID,
-		"SELECT * from commons._events LIMIT 10",
-		option.WithWarnings())
+		"SELECT * from commons._events LIMIT 10")
 	s.Require().NoError(err)
 	s.Assert().Contains(result.Collections, "commons._events")
 }


### PR DESCRIPTION
As titled, we are removing the "generate warnings" feature