### PR TITLE
support waiting until a collection can be queried

### DIFF
--- a/rockset.go
+++ b/rockset.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"regexp"
 
 	"github.com/rs/zerolog"
 
@@ -224,6 +225,28 @@ func (rc *RockClient) Ping(ctx context.Context) error {
 	const goRockset = "GO ROCKSET!"
 	if ping.Message != goRockset {
 		return fmt.Errorf("unexpected message: %s", ping.Message)
+	}
+
+	return nil
+}
+
+const (
+	entityRegexpString = "^[[:alnum:]][[:alnum:]-_]*$"
+	maxEntityLength    = 100
+)
+
+var (
+	entityRegexp = regexp.MustCompile(entityRegexpString)
+)
+
+// ValidEntityName is used to validate if a name is valid for a workspace, collection, etc
+func ValidEntityName(name string) error {
+	if len(name) > maxEntityLength {
+		return fmt.Errorf("name must be less than %d characters", maxEntityLength)
+	}
+
+	if !entityRegexp.MatchString(name) {
+		return fmt.Errorf("invalid name, must match `%s`", entityRegexpString)
 	}
 
 	return nil

--- a/rockset_test.go
+++ b/rockset_test.go
@@ -326,3 +326,29 @@ func TestRockClient_Ping(t *testing.T) {
 	err := rc.Ping(ctx)
 	require.NoError(t, err)
 }
+
+func TestValidCollectionName(t *testing.T) {
+	tests := []struct {
+		name   string
+		errStr string
+	}{
+		{"_123", "invalid name, must match `^[[:alnum:]][[:alnum:]-_]*$`"},
+		{"abc", ""},
+		{
+			"a1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
+			"name must be less than 100 characters",
+		},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			err := rockset.ValidEntityName(tst.name)
+			if tst.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Equal(t, tst.errStr, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
needed in the terraform provider, to work around eventual consistency for collection state when creating a dependent view