### PR TITLE
refactor error test into their own packages

### DIFF
--- a/aliases.go
+++ b/aliases.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
 )
@@ -38,7 +39,7 @@ func (rc *RockClient) CreateAlias(ctx context.Context, workspace, alias string, 
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -60,7 +61,7 @@ func (rc *RockClient) DeleteAlias(ctx context.Context, workspace, alias string) 
 	err := rc.Retry(ctx, func() error {
 		_, httpResp, err := q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	log.Debug().Str("alias", alias).Msg("alias deleted")
@@ -81,7 +82,7 @@ func (rc *RockClient) GetAlias(ctx context.Context, workspace, alias string) (op
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -113,14 +114,14 @@ func (rc *RockClient) ListAliases(ctx context.Context, options ...option.ListAli
 		err = rc.Retry(ctx, func() error {
 			resp, httpResp, err = q.Execute()
 
-			return NewErrorWithStatusCode(err, httpResp)
+			return rockerr.NewWithStatusCode(err, httpResp)
 		})
 	} else {
 		q := rc.AliasesApi.WorkspaceAliases(ctx, opts.Workspace)
 		err = rc.Retry(ctx, func() error {
 			resp, httpResp, err = q.Execute()
 
-			return NewErrorWithStatusCode(err, httpResp)
+			return rockerr.NewWithStatusCode(err, httpResp)
 		})
 	}
 
@@ -156,7 +157,7 @@ func (rc *RockClient) UpdateAlias(ctx context.Context, workspace, alias string, 
 	err = rc.Retry(ctx, func() error {
 		_, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {

--- a/aliases_test.go
+++ b/aliases_test.go
@@ -1,11 +1,12 @@
 package rockset_test
 
 import (
-	"github.com/stretchr/testify/suite"
+	"github.com/rockset/rockset-go-client/internal/test"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/rockset/rockset-go-client"
 	"github.com/rockset/rockset-go-client/option"
@@ -24,7 +25,7 @@ func TestAliasIntegrationSuite(t *testing.T) {
 }
 
 func (s *AliasIntegrationSuite) TestGetAlias() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	alias, err := s.rc.GetAlias(ctx, persistentWorkspace, persistentAlias)
 	require.NoError(s.T(), err)
@@ -32,7 +33,7 @@ func (s *AliasIntegrationSuite) TestGetAlias() {
 }
 
 func (s *AliasIntegrationSuite) TestListAliases() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	aliases, err := s.rc.ListAliases(ctx)
 	require.NoError(s.T(), err)
@@ -42,7 +43,7 @@ func (s *AliasIntegrationSuite) TestListAliases() {
 }
 
 func (s *AliasIntegrationSuite) TestListAliasesForWorkspace() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	aliases, err := s.rc.ListAliases(ctx, option.WithAliasWorkspace(persistentWorkspace))
 	require.NoError(s.T(), err)
@@ -52,7 +53,7 @@ func (s *AliasIntegrationSuite) TestListAliasesForWorkspace() {
 }
 
 func (s *AliasIntegrationSuite) TestAliases() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.CreateAlias(ctx, persistentWorkspace, s.alias, []string{"commons._events"})
 	require.NoError(s.T(), err)

--- a/api_keys.go
+++ b/api_keys.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
 )
@@ -32,7 +33,7 @@ func (rc *RockClient) CreateAPIKey(ctx context.Context, keyName string,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = createReq.Body(*b).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -69,7 +70,7 @@ func (rc *RockClient) GetAPIKey(ctx context.Context, name string,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = getReq.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -102,7 +103,7 @@ func (rc *RockClient) DeleteAPIKey(ctx context.Context, keyName string, options 
 	err = rc.Retry(ctx, func() error {
 		_, httpResp, err = getReq.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -136,7 +137,7 @@ func (rc *RockClient) ListAPIKeys(ctx context.Context, options ...option.APIKeyO
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = getReq.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -176,7 +177,7 @@ func (rc *RockClient) UpdateAPIKey(ctx context.Context, keyName string,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = updateReq.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {

--- a/api_keys_test.go
+++ b/api_keys_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/internal/test"
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
 )
@@ -31,20 +32,20 @@ func TestSuiteAPIKey(t *testing.T) {
 const IntegrationTestRole = "integration-test"
 
 func (s *SuiteAPIKey) SetupSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 	key, err := s.rc.CreateAPIKey(ctx, s.keyName, option.WithRole(IntegrationTestRole))
 	s.Require().NoError(err)
 	s.key = key
 }
 
 func (s *SuiteAPIKey) TearDownSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 	err := s.rc.DeleteAPIKey(ctx, s.keyName)
 	s.Require().NoError(err)
 }
 
 func (s *SuiteAPIKey) TestGetAPIKey() {
-	ctx := testCtx()
+	ctx := test.Context()
 	key, err := s.rc.GetAPIKey(ctx, s.keyName)
 	s.Require().NoError(err)
 	s.Equal(6, len(key.GetKey()), "key hash should be 6 characters")
@@ -53,14 +54,14 @@ func (s *SuiteAPIKey) TestGetAPIKey() {
 }
 
 func (s *SuiteAPIKey) TestUpdateAPIKey() {
-	ctx := testCtx()
+	ctx := test.Context()
 	key, err := s.rc.UpdateAPIKey(ctx, s.keyName, option.State(option.KeySuspended))
 	s.Require().NoError(err)
 	s.NotEqual(option.KeyActive, key.GetState())
 }
 
 func (s *SuiteAPIKey) TestListAPIKeys() {
-	ctx := testCtx()
+	ctx := test.Context()
 	keys, err := s.rc.ListAPIKeys(ctx)
 	s.Require().NoError(err)
 

--- a/collections.go
+++ b/collections.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
 )
@@ -21,7 +22,7 @@ func (rc *RockClient) GetCollection(ctx context.Context, workspace, name string)
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = getReq.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -50,7 +51,7 @@ func (rc *RockClient) ListCollections(ctx context.Context,
 		err = rc.Retry(ctx, func() error {
 			resp, httpResp, err = listReq.Execute()
 
-			return NewErrorWithStatusCode(err, httpResp)
+			return rockerr.NewWithStatusCode(err, httpResp)
 		})
 	} else {
 		listWsReq := rc.CollectionsApi.WorkspaceCollections(ctx, *opts.Workspace)
@@ -58,7 +59,7 @@ func (rc *RockClient) ListCollections(ctx context.Context,
 		err = rc.Retry(ctx, func() error {
 			resp, httpResp, err = listWsReq.Execute()
 
-			return NewErrorWithStatusCode(err, httpResp)
+			return rockerr.NewWithStatusCode(err, httpResp)
 		})
 	}
 
@@ -76,7 +77,7 @@ func (rc *RockClient) DeleteCollection(ctx context.Context, workspace, name stri
 	err := rc.Retry(ctx, func() error {
 		_, httpResp, err := deleteReq.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	return err
@@ -130,7 +131,7 @@ func (rc *RockClient) UpdateCollection(ctx context.Context, workspace, name stri
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = updateReq.Body(request).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 	if err != nil {
 		return openapi.Collection{}, err
@@ -190,7 +191,7 @@ func (rc *RockClient) CreateCollection(ctx context.Context, workspace, name stri
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = createReq.Body(request).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 	if err != nil {
 		return openapi.Collection{}, err
@@ -255,7 +256,7 @@ func (rc *RockClient) CreateKinesisCollection(ctx context.Context,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = createReq.Body(*createParams).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -298,7 +299,7 @@ func (rc *RockClient) CreateGCSCollection(ctx context.Context,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = createReq.Body(*createParams).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -341,7 +342,7 @@ func (rc *RockClient) CreateDynamoDBCollection(ctx context.Context,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = createReq.Body(*createParams).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -385,7 +386,7 @@ func (rc *RockClient) CreateFileUploadCollection(ctx context.Context,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = createReq.Body(*createParams).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 	if err != nil {
 		return openapi.Collection{}, err
@@ -429,7 +430,7 @@ func (rc *RockClient) CreateKafkaCollection(ctx context.Context, workspace, name
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = createReq.Body(*createParams).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -472,7 +473,7 @@ func (rc *RockClient) CreateMongoDBCollection(ctx context.Context,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = createReq.Body(*createParams).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 	if err != nil {
 		return openapi.Collection{}, err

--- a/collections_cc_kc_test.go
+++ b/collections_cc_kc_test.go
@@ -4,13 +4,16 @@ package rockset_test
 
 import (
 	"context"
-	"github.com/ory/dockertest/v3"
-	"github.com/ory/dockertest/v3/docker"
-	"github.com/rockset/rockset-go-client"
-	"github.com/rockset/rockset-go-client/option"
-	"github.com/stretchr/testify/suite"
 	"testing"
 	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/internal/test"
+	"github.com/rockset/rockset-go-client/option"
 )
 
 type ConfluentCloudWithKafkaConnectIntegrationSuite struct {
@@ -27,35 +30,35 @@ type ConfluentCloudWithKafkaConnectIntegrationSuite struct {
 // Test creating an integration and collection for Confluent Cloud with a local kafka-connect
 func TestConfluentCloudWithKafkaConnectIntegrationSuite(t *testing.T) {
 	t.Skip("skipping kafka tests - too flakey :(")
-	skipUnlessIntegrationTest(t)
-	skipUnlessDocker(t)
+	test.SkipUnlessIntegrationTest(t)
+	test.SkipUnlessDocker(t)
 
 	name := randomName("cckc")
 
 	s := ConfluentCloudWithKafkaConnectIntegrationSuite{
-		rc: testClient(t),
+		rc: test.Client(t),
 		kc: kafkaConfig{
 			topic:           "test_json",
 			integrationName: name,
 			workspace:       name,
 			collection:      name,
 		},
-		bootstrapServers: skipUnlessEnvSet(t, "CC_BOOTSTRAP_SERVERS"),
-		confluentKey:     skipUnlessEnvSet(t, "CC_KEY"),
-		confluentSecret:  skipUnlessEnvSet(t, "CC_SECRET"),
+		bootstrapServers: test.SkipUnlessEnvSet(t, "CC_BOOTSTRAP_SERVERS"),
+		confluentKey:     test.SkipUnlessEnvSet(t, "CC_KEY"),
+		confluentSecret:  test.SkipUnlessEnvSet(t, "CC_SECRET"),
 	}
 	suite.Run(t, &s)
 }
 
 func (s *ConfluentCloudWithKafkaConnectIntegrationSuite) TestKafka() {
-	ctx := testCtx()
+	ctx := test.Context()
 	c, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 	testKafka(c, s.T(), s.rc, s.kc)
 }
 
 func (s *ConfluentCloudWithKafkaConnectIntegrationSuite) SetupSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 	var err error
 
 	_, err = s.rc.CreateWorkspace(ctx, s.kc.workspace)
@@ -89,7 +92,7 @@ func (s *ConfluentCloudWithKafkaConnectIntegrationSuite) SetupSuite() {
 }
 
 func (s *ConfluentCloudWithKafkaConnectIntegrationSuite) TearDownSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	// TODO don't hardcode the URL
 	if err := deleteConnector("http://localhost:8083/connectors", s.kc.integrationName); err == nil {

--- a/collections_cc_test.go
+++ b/collections_cc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/internal/test"
 	"github.com/rockset/rockset-go-client/option"
 )
 
@@ -27,23 +28,23 @@ type ConfluentCloudIntegrationSuite struct {
 // Test creating an integration and collection for Confluent Cloud
 func TestConfluentCloudIntegrationSuite(t *testing.T) {
 	t.Skip("skipping kafka tests - too flakey :(")
-	skipUnlessIntegrationTest(t)
+	test.SkipUnlessIntegrationTest(t)
 
 	s := ConfluentCloudIntegrationSuite{
-		rc:               testClient(t),
+		rc:               test.Client(t),
 		integrationName:  randomName("integration"),
 		ws:               randomName("cc"),
 		coll:             randomName("cc"),
 		topic:            "test_json",
-		bootstrapServers: skipUnlessEnvSet(t, "CC_BOOTSTRAP_SERVERS"),
-		confluentKey:     skipUnlessEnvSet(t, "CC_KEY"),
-		confluentSecret:  skipUnlessEnvSet(t, "CC_SECRET"),
+		bootstrapServers: test.SkipUnlessEnvSet(t, "CC_BOOTSTRAP_SERVERS"),
+		confluentKey:     test.SkipUnlessEnvSet(t, "CC_KEY"),
+		confluentSecret:  test.SkipUnlessEnvSet(t, "CC_SECRET"),
 	}
 	suite.Run(t, &s)
 }
 
 func (s *ConfluentCloudIntegrationSuite) SetupSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.CreateWorkspace(ctx, s.ws)
 	s.Require().NoError(err)
@@ -61,7 +62,7 @@ func (s *ConfluentCloudIntegrationSuite) SetupSuite() {
 }
 
 func (s *ConfluentCloudIntegrationSuite) TearDownSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	err := s.rc.DeleteIntegration(ctx, s.integrationName)
 	s.NoError(err)
@@ -71,7 +72,7 @@ func (s *ConfluentCloudIntegrationSuite) TearDownSuite() {
 }
 
 func (s *ConfluentCloudIntegrationSuite) TestCreateJSONCollection() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.CreateKafkaCollection(ctx, s.ws, s.coll,
 		option.WithCollectionDescription(description()),
@@ -92,7 +93,7 @@ func (s *ConfluentCloudIntegrationSuite) TestCreateJSONCollection() {
 }
 
 func (s *ConfluentCloudIntegrationSuite) TestDeleteCollection() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	err := s.rc.DeleteCollection(ctx, s.ws, s.coll)
 	s.Require().NoError(err)

--- a/collections_kafka_test.go
+++ b/collections_kafka_test.go
@@ -5,15 +5,18 @@ package rockset_test
 import (
 	"errors"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/go-zookeeper/zk"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
-	"github.com/rockset/rockset-go-client"
-	"github.com/rockset/rockset-go-client/option"
 	"github.com/stretchr/testify/suite"
-	"testing"
-	"time"
+
+	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/internal/test"
+	"github.com/rockset/rockset-go-client/option"
 )
 
 type KafkaIntegrationSuite struct {
@@ -33,32 +36,32 @@ type KafkaIntegrationSuite struct {
 // Test creating an integration and collection for a self-managed kafka with local kafka-connect
 func TestKafkaIntegrationSuite(t *testing.T) {
 	t.Skip("skipping kafka tests - too flakey :(")
-	skipUnlessIntegrationTest(t)
-	skipUnlessDocker(t)
+	test.SkipUnlessIntegrationTest(t)
+	test.SkipUnlessDocker(t)
 
 	s := KafkaIntegrationSuite{
-		rc: testClient(t),
+		rc: test.Client(t),
 		kc: kafkaConfig{
 			topic:           "test_json",
 			integrationName: randomName("kafka"),
 			workspace:       randomName("kafka"),
 			collection:      randomName("kafka"),
 		},
-		bootstrapServers: skipUnlessEnvSet(t, "CC_BOOTSTRAP_SERVERS"),
-		confluentKey:     skipUnlessEnvSet(t, "CC_KEY"),
-		confluentSecret:  skipUnlessEnvSet(t, "CC_SECRET"),
+		bootstrapServers: test.SkipUnlessEnvSet(t, "CC_BOOTSTRAP_SERVERS"),
+		confluentKey:     test.SkipUnlessEnvSet(t, "CC_KEY"),
+		confluentSecret:  test.SkipUnlessEnvSet(t, "CC_SECRET"),
 	}
 	suite.Run(t, &s)
 }
 
 func (s *KafkaIntegrationSuite) TestKafka() {
-	ctx := testCtx()
+	ctx := test.Context()
 	testKafka(ctx, s.T(), s.rc, s.kc)
 }
 
 func (s *KafkaIntegrationSuite) SetupSuite() {
 	var err error
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err = s.rc.CreateWorkspace(ctx, s.kc.workspace)
 	s.dockerPool, err = dockertest.NewPool("")
@@ -177,7 +180,7 @@ func (s *KafkaIntegrationSuite) SetupSuite() {
 }
 
 func (s *KafkaIntegrationSuite) TearDownSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 	var err error
 
 	if err = s.rc.DeleteCollection(ctx, s.kc.workspace, s.kc.collection); err == nil {

--- a/collections_test.go
+++ b/collections_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rockset/rockset-go-client"
 	"github.com/rockset/rockset-go-client/dataset"
+	"github.com/rockset/rockset-go-client/internal/test"
 	"github.com/rockset/rockset-go-client/option"
 )
 
@@ -25,7 +26,7 @@ func TestCollectionIntegrationSuite(t *testing.T) {
 }
 
 func (s *CollectionTestSuite) SetupSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 	_, err := s.rc.CreateWorkspace(ctx, s.ws)
 	s.Require().NoError(err)
 
@@ -34,7 +35,7 @@ func (s *CollectionTestSuite) SetupSuite() {
 }
 
 func (s *CollectionTestSuite) TearDownSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 	var deleted []string
 
 	for _, c := range s.collections {
@@ -58,7 +59,7 @@ func (s *CollectionTestSuite) BeforeTest(suiteName, testName string) {
 }
 
 func (s *CollectionTestSuite) TestGetCollection() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	collection, err := s.rc.GetCollection(ctx, persistentWorkspace, persistentCollection)
 	s.NoError(err)
@@ -66,7 +67,7 @@ func (s *CollectionTestSuite) TestGetCollection() {
 }
 
 func (s *CollectionTestSuite) TestListAllCollections() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	collections, err := s.rc.ListCollections(ctx)
 	s.NoError(err)
@@ -75,7 +76,7 @@ func (s *CollectionTestSuite) TestListAllCollections() {
 }
 
 func (s *CollectionTestSuite) TestListCollectionsInWorkspace() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	collections, err := s.rc.ListCollections(ctx, option.WithWorkspace(persistentWorkspace))
 	s.NoError(err)
@@ -84,7 +85,7 @@ func (s *CollectionTestSuite) TestListCollectionsInWorkspace() {
 }
 
 func (s *CollectionTestSuite) TestCreateSampleCitiesCollection() {
-	ctx := testCtx()
+	ctx := test.Context()
 	name := randomName("cities")
 
 	_, err := s.rc.CreateCollection(ctx, s.ws, name,
@@ -97,7 +98,7 @@ func (s *CollectionTestSuite) TestCreateSampleCitiesCollection() {
 }
 
 func (s *CollectionTestSuite) TestCreateSampleMoviesCollection() {
-	ctx := testCtx()
+	ctx := test.Context()
 	name := randomName("movies")
 
 	_, err := s.rc.CreateCollection(ctx, s.ws, name,
@@ -111,7 +112,7 @@ func (s *CollectionTestSuite) TestCreateSampleMoviesCollection() {
 }
 
 func (s *CollectionTestSuite) TestUpdateCollection() {
-	ctx := testCtx()
+	ctx := test.Context()
 	name := randomName("update")
 
 	_, err := s.rc.CreateCollection(ctx, s.ws, name,

--- a/documents.go
+++ b/documents.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
 )
 
@@ -39,7 +40,7 @@ func (rc *RockClient) AddDocuments(ctx context.Context, workspace, collection st
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -85,7 +86,7 @@ func (rc *RockClient) PatchDocuments(ctx context.Context, workspace, collection 
 	err = rc.Retry(ctx, func() error {
 		resp, err = rc.RockConfig.cfg.HTTPClient.Do(req)
 
-		return NewErrorWithStatusCode(err, resp)
+		return rockerr.NewWithStatusCode(err, resp)
 	})
 	if err != nil {
 		return nil, err
@@ -117,7 +118,7 @@ func (rc *RockClient) PatchDocuments(ctx context.Context, workspace, collection 
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
-	return nil, Error{
+	return nil, rockerr.Error{
 		ErrorModel: &em,
 		Cause:      fmt.Errorf("unexpected http response (%d): %s", resp.StatusCode, resp.Status),
 	}
@@ -180,7 +181,7 @@ func (rc *RockClient) DeleteDocuments(ctx context.Context, workspace, collection
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {

--- a/documents_test.go
+++ b/documents_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/internal/test"
 )
 
 type DocumentIntegrationSuite struct {
@@ -29,7 +30,7 @@ func TestDocumentSuite(t *testing.T) {
 }
 
 func (s *DocumentIntegrationSuite) SetupSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.CreateWorkspace(ctx, s.ws)
 	s.Require().NoError(err)
@@ -42,7 +43,7 @@ func (s *DocumentIntegrationSuite) SetupSuite() {
 }
 
 func (s *DocumentIntegrationSuite) TearDownSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	err := s.rc.DeleteCollection(ctx, s.ws, s.collection)
 	s.Require().NoError(err)
@@ -55,7 +56,7 @@ func (s *DocumentIntegrationSuite) TearDownSuite() {
 }
 
 func (s *DocumentIntegrationSuite) TestAddDocument() {
-	ctx := testCtx()
+	ctx := test.Context()
 	rc, _ := vcrTestClient(s.T(), s.T().Name())
 
 	type doc struct {
@@ -74,7 +75,7 @@ func (s *DocumentIntegrationSuite) TestAddDocument() {
 }
 
 func (s *DocumentIntegrationSuite) TestPatchDocument() {
-	ctx := testCtx()
+	ctx := test.Context()
 	rc, _ := vcrTestClient(s.T(), s.T().Name())
 	s.T().Logf("t: %s", s.T().Name())
 
@@ -99,7 +100,7 @@ func (s *DocumentIntegrationSuite) TestPatchDocument() {
 // TestRemoveDocument should really be named TestDeleteDocument as the call is DeleteDocuments()
 // but we want the operations in alphabetical order, add/patch/remove (delete).
 func (s *DocumentIntegrationSuite) TestRemoveDocument() {
-	ctx := testCtx()
+	ctx := test.Context()
 	rc, _ := vcrTestClient(s.T(), s.T().Name())
 
 	res, err := rc.DeleteDocuments(ctx, s.ws, s.collection, []string{s.id})

--- a/errors/rockset.go
+++ b/errors/rockset.go
@@ -1,9 +1,10 @@
-package rockset
+package errors
 
 import (
 	"errors"
-	"github.com/rockset/rockset-go-client/openapi"
 	"net/http"
+
+	"github.com/rockset/rockset-go-client/openapi"
 )
 
 // Error is an error returned by the Rockset REST API.
@@ -16,8 +17,8 @@ type Error struct {
 	StatusCode int
 }
 
-// NewError wraps err in an Error that provides better error messages than the openapi.GenericOpenAPIError
-func NewError(err error) Error {
+// New wraps err in an Error that provides better error messages than the openapi.GenericOpenAPIError
+func New(err error) Error {
 	var re = Error{Cause: err}
 
 	var ge *openapi.GenericOpenAPIError
@@ -30,14 +31,14 @@ func NewError(err error) Error {
 	return re
 }
 
-// NewErrorWithStatusCode wraps err in an Error that provides better error messages than the openapi.GenericOpenAPIError,
-// and can be retried if the HTTP response StatusCode is in RetryableErrors. If err is nil, NewErrorWithStatusCode() returns nil.
-func NewErrorWithStatusCode(err error, response *http.Response) error {
+// NewWithStatusCode wraps err in an Error that provides better error messages than the openapi.GenericOpenAPIError,
+// and can be retried if the HTTP response StatusCode is in RetryableErrors. If err is nil, NewWithStatusCode() returns nil.
+func NewWithStatusCode(err error, response *http.Response) error {
 	if err == nil {
 		return nil
 	}
 
-	e := NewError(err)
+	e := New(err)
 	if response != nil {
 		e.StatusCode = response.StatusCode
 	}

--- a/errors/rockset_test.go
+++ b/errors/rockset_test.go
@@ -1,33 +1,35 @@
-package rockset_test
+package errors_test
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rockset/rockset-go-client"
+	rockerr "github.com/rockset/rockset-go-client/errors"
+	"github.com/rockset/rockset-go-client/internal/test"
 )
 
 func TestError_IsNotFoundError(t *testing.T) {
-	rc, _ := vcrTestClient(t, t.Name())
-	ctx := testCtx()
+	test.SkipUnlessIntegrationTest(t)
+	rc := test.Client(t)
+	ctx := test.Context()
 
-	_, err := rc.GetCollection(ctx, persistentWorkspace, "notfound")
+	_, err := rc.GetCollection(ctx, "notfound", "notfound")
 	require.Error(t, err)
 
-	var re rockset.Error
+	var re rockerr.Error
 	require.True(t, errors.As(err, &re))
 	assert.True(t, re.IsNotFoundError())
 	assert.Equal(t, http.StatusNotFound, re.StatusCode)
 }
 
 func TestError_NilHTTPResponse(t *testing.T) {
-	err := rockset.NewErrorWithStatusCode(errors.New("test error"), nil)
+	err := rockerr.NewWithStatusCode(errors.New("test error"), nil)
 
-	var re rockset.Error
+	var re rockerr.Error
 	require.True(t, errors.As(err, &re))
 	assert.False(t, re.IsNotFoundError())
 	assert.Equal(t, 0, re.StatusCode)

--- a/integration_azure_test.go
+++ b/integration_azure_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/internal/test"
 )
 
 type AzureIntegrationsSuite struct {
@@ -16,7 +17,7 @@ type AzureIntegrationsSuite struct {
 }
 
 func (s *AzureIntegrationsSuite) TestAzureBlob() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.CreateAzureBlobStorageIntegration(ctx, s.integrationName, s.connectionString)
 	s.Require().NoError(err)
@@ -30,7 +31,7 @@ func (s *AzureIntegrationsSuite) TestAzureBlob() {
 }
 
 func (s *AzureIntegrationsSuite) TearDownSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	// cleanup the integration if it is still around
 	_, err := s.rc.GetIntegration(ctx, s.integrationName)
@@ -42,7 +43,7 @@ func (s *AzureIntegrationsSuite) TearDownSuite() {
 }
 
 func TestAzureIntegrations(t *testing.T) {
-	connectionString := skipUnlessEnvSet(t, "AZURE_CONNECTION_STRING")
+	connectionString := test.SkipUnlessEnvSet(t, "AZURE_CONNECTION_STRING")
 	rc, randomName := vcrTestClient(t, t.Name())
 
 	s := AzureIntegrationsSuite{

--- a/integrations.go
+++ b/integrations.go
@@ -2,9 +2,11 @@ package rockset
 
 import (
 	"context"
+	"net/http"
+
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
-	"net/http"
 )
 
 func (rc *RockClient) GetIntegration(ctx context.Context, name string) (openapi.Integration, error) {
@@ -16,7 +18,7 @@ func (rc *RockClient) GetIntegration(ctx context.Context, name string) (openapi.
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = req.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 	if err != nil {
 		return openapi.Integration{}, err
@@ -34,7 +36,7 @@ func (rc *RockClient) ListIntegrations(ctx context.Context) ([]openapi.Integrati
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = req.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 	if err != nil {
 		return nil, err
@@ -51,7 +53,7 @@ func (rc *RockClient) DeleteIntegration(ctx context.Context, name string) error 
 	err = rc.Retry(ctx, func() error {
 		_, httpResp, err = req.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	return err
@@ -74,7 +76,7 @@ func (rc *RockClient) CreateAzureBlobStorageIntegration(ctx context.Context, nam
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -116,7 +118,7 @@ func (rc *RockClient) CreateS3Integration(ctx context.Context, name string, cred
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -156,7 +158,7 @@ func (rc *RockClient) CreateKinesisIntegration(ctx context.Context, name string,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -201,7 +203,7 @@ func (rc *RockClient) CreateDynamoDBIntegration(ctx context.Context, name string
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -237,7 +239,7 @@ func (rc *RockClient) CreateGCSIntegration(ctx context.Context, name, serviceAcc
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -272,7 +274,7 @@ func (rc *RockClient) CreateKafkaIntegration(ctx context.Context, name string,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -306,7 +308,7 @@ func (rc *RockClient) CreateMongoDBIntegration(ctx context.Context, name, connec
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -2,10 +2,12 @@ package rockset_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/suite"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/internal/test"
 	"github.com/rockset/rockset-go-client/option"
 )
 
@@ -30,7 +32,7 @@ func (s *IntegrationTestSuite) BeforeTest(suiteName, testName string) {
 }
 
 func (s *IntegrationTestSuite) TearDown() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	// clean up any lingering integrations
 	_ = s.rc.DeleteIntegration(ctx, s.s3Integration)
@@ -38,7 +40,7 @@ func (s *IntegrationTestSuite) TearDown() {
 }
 
 func (s *IntegrationTestSuite) TestGetIntegration() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	const iName = "acc-kafka-integration"
 	integration, err := s.rc.GetIntegration(ctx, iName)
@@ -47,14 +49,14 @@ func (s *IntegrationTestSuite) TestGetIntegration() {
 }
 
 func (s *IntegrationTestSuite) TestListIntegrations() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.ListIntegrations(ctx)
 	s.NoError(err)
 }
 
 func (s *IntegrationTestSuite) TestCreateS3Integration() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.CreateS3Integration(ctx, s.s3Integration,
 		option.AWSRole("arn:aws:iam::469279130686:role/rockset-s3-integration"),
@@ -66,9 +68,9 @@ func (s *IntegrationTestSuite) TestCreateS3Integration() {
 }
 
 func (s *IntegrationTestSuite) TestCreateGCSIntegration() {
-	saKeyFile := skipUnlessEnvSet(s.T(), "GCP_SA_KEY_JSON")
+	saKeyFile := test.SkipUnlessEnvSet(s.T(), "GCP_SA_KEY_JSON")
 
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.CreateGCSIntegration(ctx, s.gcsIntegration, saKeyFile,
 		option.WithGCSIntegrationDescription(description()))

--- a/internal/test/client.go
+++ b/internal/test/client.go
@@ -1,0 +1,15 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rockset/rockset-go-client"
+)
+
+func Client(t *testing.T) *rockset.RockClient {
+	rc, err := rockset.NewClient(rockset.WithUserAgent("rockset-go-integration-tests"))
+	require.NoError(t, err)
+	return rc
+}

--- a/internal/test/context.go
+++ b/internal/test/context.go
@@ -1,0 +1,22 @@
+package test
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// Context is helper function to create a context with a zerolog logger
+func Context() context.Context {
+	return ContextWithLevel(zerolog.WarnLevel)
+}
+
+func ContextWithLevel(lvl zerolog.Level) context.Context {
+	ctx := context.Background()
+	console := zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}
+	log := zerolog.New(console).Level(lvl).With().Timestamp().Logger()
+
+	return log.WithContext(ctx)
+}

--- a/internal/test/skip.go
+++ b/internal/test/skip.go
@@ -1,0 +1,32 @@
+package test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rockset/rockset-go-client"
+)
+
+// SkipUnlessIntegrationTest is helper function to skip unless ROCKSET_APIKEY is set
+func SkipUnlessIntegrationTest(t *testing.T) {
+	_ = SkipUnlessEnvSet(t, rockset.APIKeyEnvironmentVariableName)
+}
+
+func SkipUnlessEnvSet(t *testing.T, envName string) string {
+	env := os.Getenv(envName)
+	if env == "" {
+		t.Skipf("skipping as %s is not set", envName)
+	}
+
+	return env
+}
+
+func SkipUnlessDocker(t *testing.T) {
+	_, err := os.Stat("/var/run/docker.sock")
+	if os.IsNotExist(err) {
+		t.Skip("docker socket not present, skipping")
+	}
+	assert.NoError(t, err)
+}

--- a/organizations.go
+++ b/organizations.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
 )
 
@@ -20,7 +21,7 @@ func (rc *RockClient) GetOrganization(ctx context.Context) (openapi.Organization
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = getReq.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {

--- a/organizations_test.go
+++ b/organizations_test.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	
+	"github.com/rockset/rockset-go-client/internal/test"
 )
 
 func TestRockClient_GetOrganization(t *testing.T) {
-	ctx := testCtx()
+	ctx := test.Context()
 	rc, _ := vcrTestClient(t, t.Name())
 
 	org, err := rc.GetOrganization(ctx)

--- a/queries.go
+++ b/queries.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
 )
@@ -53,7 +54,7 @@ func queryWrapper(ctx context.Context, rc *RockClient, vID, sql string,
 			response, httpResp, err = viQuery.Body(*queryRequest).Execute()
 		}
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -83,7 +84,7 @@ func (rc *RockClient) ValidateQuery(ctx context.Context, sql string,
 	err = rc.Retry(ctx, func() error {
 		r, httpResp, err = q.Body(*rq).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -104,7 +105,7 @@ func (rc *RockClient) GetQueryInfo(ctx context.Context, queryID string) (openapi
 	err = rc.Retry(ctx, func() error {
 		response, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -125,7 +126,7 @@ func (rc *RockClient) GetQueryResults(ctx context.Context, queryID string) (open
 	err = rc.Retry(ctx, func() error {
 		response, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -146,7 +147,7 @@ func (rc *RockClient) ListActiveQueries(ctx context.Context) ([]openapi.QueryInf
 	err = rc.Retry(ctx, func() error {
 		response, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	return response.Data, nil
@@ -163,7 +164,7 @@ func (rc *RockClient) CancelQuery(ctx context.Context, queryID string) (openapi.
 	err = rc.Retry(ctx, func() error {
 		response, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	return *response.Data, nil

--- a/queries_test.go
+++ b/queries_test.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/rockset/rockset-go-client"
-	"github.com/rockset/rockset-go-client/option"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/rockset/rockset-go-client"
+	rockerr "github.com/rockset/rockset-go-client/errors"
+	"github.com/rockset/rockset-go-client/internal/test"
+	"github.com/rockset/rockset-go-client/option"
 )
 
 // for anyone poking around in the code, rockset.sleep() only works for this test org as no sane person would want
@@ -30,21 +33,21 @@ func (s *QueryIntegrationSuite) BeforeTest(suiteName, testName string) {
 }
 
 func (s *QueryIntegrationSuite) TestQuery() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.Query(ctx, "SELECT 1")
 	s.Require().NoError(err)
 }
 
 func (s *QueryIntegrationSuite) TestListQueries() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.ListActiveQueries(ctx)
 	s.Require().NoError(err)
 }
 
 func (s *QueryIntegrationSuite) TestAsyncQuery() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	resp, err := s.rc.Query(ctx, slowQuery,
 		option.WithAsync(),
@@ -59,7 +62,7 @@ func (s *QueryIntegrationSuite) TestAsyncQuery() {
 }
 
 func (s *QueryIntegrationSuite) TestAsyncQueryWithClientTimeout() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	resp, err := s.rc.Query(ctx, slowQuery,
 		option.WithAsync(),
@@ -76,20 +79,20 @@ func (s *QueryIntegrationSuite) TestAsyncQueryWithClientTimeout() {
 }
 
 func (s *QueryIntegrationSuite) TestQueryWithTimeout() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.Query(ctx, slowQuery,
 		option.WithTimeout(1000),
 	)
 	s.Require().Error(err)
 
-	var re rockset.Error
+	var re rockerr.Error
 	s.Require().True(errors.As(err, &re))
 	s.Assert().Equal("QUERY_TIMEOUT", *re.Type)
 }
 
 func (s *QueryIntegrationSuite) TestCancelQuery() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	resp, err := s.rc.Query(ctx, slowQuery,
 		option.WithAsync(),
@@ -106,7 +109,7 @@ func (s *QueryIntegrationSuite) TestCancelQuery() {
 }
 
 func (s *QueryIntegrationSuite) TestValidateQuery() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.ValidateQuery(ctx, "SELECT 1")
 	s.Require().NoError(err)

--- a/query_lambdas.go
+++ b/query_lambdas.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
 )
@@ -45,7 +46,7 @@ func (rc *RockClient) CreateQueryLambda(ctx context.Context, workspace, name, sq
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -67,7 +68,7 @@ func (rc *RockClient) DeleteQueryLambda(ctx context.Context, workspace, name str
 	err = rc.Retry(ctx, func() error {
 		_, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -109,7 +110,7 @@ func (rc *RockClient) UpdateQueryLambda(ctx context.Context, workspace, name, sq
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -137,7 +138,7 @@ func (rc *RockClient) CreateQueryLambdaTag(ctx context.Context, workspace, name,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -158,7 +159,7 @@ func (rc *RockClient) DeleteQueryLambdaVersion(ctx context.Context, workspace, n
 	err = rc.Retry(ctx, func() error {
 		_, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -179,7 +180,7 @@ func (rc *RockClient) DeleteQueryLambdaTag(ctx context.Context, workspace, name,
 	err = rc.Retry(ctx, func() error {
 		_, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -212,21 +213,21 @@ func (rc *RockClient) ExecuteQueryLambda(ctx context.Context, workspace, name st
 		err = rc.Retry(ctx, func() error {
 			resp, httpResp, err = q.Body(req.ExecuteQueryLambdaRequest).Execute()
 
-			return NewErrorWithStatusCode(err, httpResp)
+			return rockerr.NewWithStatusCode(err, httpResp)
 		})
 	} else if req.Tag != "" {
 		q := rc.QueryLambdasApi.ExecuteQueryLambdaByTag(ctx, workspace, name, req.Tag)
 		err = rc.Retry(ctx, func() error {
 			resp, httpResp, err = q.Body(req.ExecuteQueryLambdaRequest).Execute()
 
-			return NewErrorWithStatusCode(err, httpResp)
+			return rockerr.NewWithStatusCode(err, httpResp)
 		})
 	} else {
 		q := rc.QueryLambdasApi.ExecuteQueryLambdaByTag(ctx, workspace, name, LatestTag)
 		err = rc.Retry(ctx, func() error {
 			resp, httpResp, err = q.Body(req.ExecuteQueryLambdaRequest).Execute()
 
-			return NewErrorWithStatusCode(err, httpResp)
+			return rockerr.NewWithStatusCode(err, httpResp)
 		})
 	}
 
@@ -248,7 +249,7 @@ func (rc *RockClient) GetQueryLambdaVersionByTag(ctx context.Context,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -269,7 +270,7 @@ func (rc *RockClient) GetQueryLambdaVersion(ctx context.Context,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -298,14 +299,14 @@ func (rc *RockClient) ListQueryLambdas(ctx context.Context,
 		err = rc.Retry(ctx, func() error {
 			resp, httpResp, err = q.Execute()
 
-			return NewErrorWithStatusCode(err, httpResp)
+			return rockerr.NewWithStatusCode(err, httpResp)
 		})
 	} else {
 		q := rc.QueryLambdasApi.ListQueryLambdasInWorkspace(ctx, *opts.Workspace)
 		err = rc.Retry(ctx, func() error {
 			resp, httpResp, err = q.Execute()
 
-			return NewErrorWithStatusCode(err, httpResp)
+			return rockerr.NewWithStatusCode(err, httpResp)
 		})
 	}
 
@@ -327,7 +328,7 @@ func (rc *RockClient) ListQueryLambdaVersions(ctx context.Context,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -348,7 +349,7 @@ func (rc *RockClient) ListQueryLambdaTags(ctx context.Context, workspace,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {

--- a/query_lambdas_test.go
+++ b/query_lambdas_test.go
@@ -6,13 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/rockset/rockset-go-client/internal/test"
 	"github.com/rockset/rockset-go-client/option"
 )
 
 func TestRockClient_CreateQueryLambda(t *testing.T) {
 	rc, randomName := vcrTestClient(t, t.Name())
 
-	ctx := testCtx()
+	ctx := test.Context()
 	ws := "acc"
 	name := randomName("ql")
 
@@ -41,7 +42,7 @@ const (
 
 func TestRockClient_GetQueryLambdaVersionByTag(t *testing.T) {
 	rc, _ := vcrTestClient(t, t.Name())
-	ctx := testCtx()
+	ctx := test.Context()
 
 	version, err := rc.GetQueryLambdaVersionByTag(ctx, persistentWorkspace, qlName, qlTag)
 	require.NoError(t, err)
@@ -50,7 +51,7 @@ func TestRockClient_GetQueryLambdaVersionByTag(t *testing.T) {
 
 func TestRockClient_GetQueryLambdaVersion(t *testing.T) {
 	rc, _ := vcrTestClient(t, t.Name())
-	ctx := testCtx()
+	ctx := test.Context()
 
 	version, err := rc.GetQueryLambdaVersion(ctx, persistentWorkspace, qlName, qlVersion)
 	require.NoError(t, err)
@@ -59,7 +60,7 @@ func TestRockClient_GetQueryLambdaVersion(t *testing.T) {
 
 func TestRockClient_ListQueryLambdas(t *testing.T) {
 	rc, _ := vcrTestClient(t, t.Name())
-	ctx := testCtx()
+	ctx := test.Context()
 
 	lambdas, err := rc.ListQueryLambdas(ctx)
 	require.NoError(t, err)
@@ -71,7 +72,7 @@ func TestRockClient_ListQueryLambdas(t *testing.T) {
 
 func TestRockClient_ListQueryLambdas_workspace(t *testing.T) {
 	rc, _ := vcrTestClient(t, t.Name())
-	ctx := testCtx()
+	ctx := test.Context()
 
 	lambdas, err := rc.ListQueryLambdas(ctx, option.WithQueryLambdaWorkspace(persistentWorkspace))
 	require.NoError(t, err)
@@ -83,7 +84,7 @@ func TestRockClient_ListQueryLambdas_workspace(t *testing.T) {
 
 func TestRockClient_ListQueryLambdaVersions(t *testing.T) {
 	rc, _ := vcrTestClient(t, t.Name())
-	ctx := testCtx()
+	ctx := test.Context()
 
 	versions, err := rc.ListQueryLambdaVersions(ctx, persistentWorkspace, qlName)
 	require.NoError(t, err)
@@ -95,7 +96,7 @@ func TestRockClient_ListQueryLambdaVersions(t *testing.T) {
 
 func TestRockClient_ListQueryLambdaTags(t *testing.T) {
 	rc, _ := vcrTestClient(t, t.Name())
-	ctx := testCtx()
+	ctx := test.Context()
 
 	tags, err := rc.ListQueryLambdaTags(ctx, persistentWorkspace, qlName)
 	require.NoError(t, err)

--- a/retry_test.go
+++ b/retry_test.go
@@ -2,20 +2,23 @@ package rockset_test
 
 import (
 	"errors"
-	"github.com/rockset/rockset-go-client/openapi"
-	"github.com/stretchr/testify/suite"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/rockset/rockset-go-client"
+	rockerr "github.com/rockset/rockset-go-client/errors"
+	"github.com/rockset/rockset-go-client/internal/test"
+	"github.com/rockset/rockset-go-client/openapi"
 )
 
 func fakeError(code int) error {
 	t := strings.Join(strings.Fields(http.StatusText(code)), "")
-	return rockset.Error{
+	return rockerr.Error{
 		ErrorModel: &openapi.ErrorModel{
 			Type: &t,
 		},
@@ -33,7 +36,7 @@ func TestExponentialRetrySuite(t *testing.T) {
 }
 
 func (s *ExponentialRetrySuite) TestDefaultRetry() {
-	ctx := testCtx()
+	ctx := test.Context()
 	var count int
 
 	err := rockset.ExponentialRetry{
@@ -51,7 +54,7 @@ func (s *ExponentialRetrySuite) TestDefaultRetry() {
 }
 
 func (s *ExponentialRetrySuite) TestDefaultRetryWithFailure() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	err := rockset.ExponentialRetry{
 		MaxBackoff:   time.Second,
@@ -70,7 +73,7 @@ func (r retryableErr) Error() string   { return r.err }
 func (r retryableErr) Retryable() bool { return true }
 
 func (s *ExponentialRetrySuite) TestDefaultRetryFn() {
-	ctx := testCtx()
+	ctx := test.Context()
 	var count int
 
 	err := rockset.ExponentialRetry{
@@ -89,7 +92,7 @@ func (s *ExponentialRetrySuite) TestDefaultRetryFn() {
 }
 
 func (s *ExponentialRetrySuite) TestExponentialRetry_RetryFn() {
-	ctx := testCtx()
+	ctx := test.Context()
 	var count int
 
 	err := rockset.ExponentialRetry{
@@ -110,7 +113,7 @@ func (s *ExponentialRetrySuite) TestExponentialRetry_RetryFn() {
 }
 
 func (s *ExponentialRetrySuite) TestExponentialRetry_RetryWithCheck() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	var i int
 	err := rockset.ExponentialRetry{

--- a/roles.go
+++ b/roles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
 )
@@ -43,7 +44,7 @@ func (rc *RockClient) CreateRole(ctx context.Context, roleName string,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = createReq.Body(*b).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -80,7 +81,7 @@ func (rc *RockClient) UpdateRole(ctx context.Context, roleName string,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = createReq.Body(*b).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -102,7 +103,7 @@ func (rc *RockClient) DeleteRole(ctx context.Context, roleName string) error {
 	err = rc.Retry(ctx, func() error {
 		_, httpResp, err = getReq.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -125,7 +126,7 @@ func (rc *RockClient) GetRole(ctx context.Context, roleName string) (openapi.Rol
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = getReq.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -148,7 +149,7 @@ func (rc *RockClient) ListRoles(ctx context.Context) ([]openapi.Role, error) {
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = getReq.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {

--- a/roles_test.go
+++ b/roles_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/internal/test"
 	"github.com/rockset/rockset-go-client/option"
 )
 
@@ -25,13 +26,13 @@ func TestRoleIntegration(t *testing.T) {
 }
 
 func (s *RoleIntegrationSuite) TearDownSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 	err := s.rc.DeleteRole(ctx, s.name)
 	s.NoError(err)
 }
 
 func (s *RoleIntegrationSuite) TestCreateRole() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	role, err := s.rc.CreateRole(ctx, s.name,
 		option.WithRoleDescription(description()),
@@ -42,7 +43,7 @@ func (s *RoleIntegrationSuite) TestCreateRole() {
 }
 
 func (s *RoleIntegrationSuite) TestGetRole() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	role, err := s.rc.GetRole(ctx, s.name)
 	s.NoError(err)
@@ -50,14 +51,14 @@ func (s *RoleIntegrationSuite) TestGetRole() {
 }
 
 func (s *RoleIntegrationSuite) TestGetMissingRole() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.GetRole(ctx, "non-existing-role")
 	s.Error(err)
 }
 
 func (s *RoleIntegrationSuite) TestListRoles() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	roles, err := s.rc.ListRoles(ctx)
 	s.NoError(err)
@@ -72,7 +73,7 @@ func (s *RoleIntegrationSuite) TestListRoles() {
 }
 
 func (s *RoleIntegrationSuite) TestUpdate() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	role, err := s.rc.UpdateRole(ctx, s.name,
 		option.WithGlobalPrivilege(option.ListRolesGlobal),

--- a/users.go
+++ b/users.go
@@ -2,10 +2,11 @@ package rockset
 
 import (
 	"context"
-	"github.com/rockset/rockset-go-client/option"
 	"net/http"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
+	"github.com/rockset/rockset-go-client/option"
 )
 
 // https://docs.rockset.com/rest-api/#users
@@ -24,7 +25,7 @@ func (rc *RockClient) CreateUser(ctx context.Context, email string, roles []stri
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -64,7 +65,7 @@ func (rc *RockClient) UpdateUser(ctx context.Context, email string, roles []stri
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -86,7 +87,7 @@ func (rc *RockClient) DeleteUser(ctx context.Context, email string) error {
 	err = rc.Retry(ctx, func() error {
 		_, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -109,7 +110,7 @@ func (rc *RockClient) GetCurrentUser(ctx context.Context) (openapi.User, error) 
 	err = rc.Retry(ctx, func() error {
 		user, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -132,7 +133,7 @@ func (rc *RockClient) GetUser(ctx context.Context, email string) (openapi.User, 
 	err = rc.Retry(ctx, func() error {
 		user, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -155,7 +156,7 @@ func (rc *RockClient) ListUsers(ctx context.Context) ([]openapi.User, error) {
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {

--- a/users_test.go
+++ b/users_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/internal/test"
 	"github.com/rockset/rockset-go-client/option"
 )
 
@@ -31,14 +32,14 @@ func TestUserIntegration(t *testing.T) {
 }
 
 func (s *UserIntegrationSuite) TearDownSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	err := s.rc.DeleteUser(ctx, s.email)
 	s.Require().NoError(err)
 }
 
 func (s *UserIntegrationSuite) TestCreateUser() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	user, err := s.rc.CreateUser(ctx, s.email, []string{rockset.ReadOnlyRole})
 	s.Require().NoError(err)
@@ -46,7 +47,7 @@ func (s *UserIntegrationSuite) TestCreateUser() {
 }
 
 func (s *UserIntegrationSuite) TestGetCurrentUser() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	user, err := s.rc.GetCurrentUser(ctx)
 	s.Require().NoError(err)
@@ -54,7 +55,7 @@ func (s *UserIntegrationSuite) TestGetCurrentUser() {
 }
 
 func (s *UserIntegrationSuite) TestGetUser() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	user, err := s.rc.GetUser(ctx, s.email)
 	s.Require().NoError(err)
@@ -63,7 +64,7 @@ func (s *UserIntegrationSuite) TestGetUser() {
 }
 
 func (s *UserIntegrationSuite) TestListUsers() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	users, err := s.rc.ListUsers(ctx)
 	s.Require().NoError(err)
@@ -78,7 +79,7 @@ func (s *UserIntegrationSuite) TestListUsers() {
 }
 
 func (s *UserIntegrationSuite) TestUpdateUser() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := s.rc.UpdateUser(ctx, s.email, []string{rockset.MemberRole},
 		option.WithUserFirstName("first"), option.WithUserLastName("last"))

--- a/views.go
+++ b/views.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
 )
@@ -34,7 +35,7 @@ func (rc *RockClient) CreateView(ctx context.Context, workspace, view, query str
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -71,7 +72,7 @@ func (rc *RockClient) UpdateView(ctx context.Context, workspace, view, query str
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -97,7 +98,7 @@ func (rc *RockClient) DeleteView(ctx context.Context, workspace, view string) er
 	err = rc.Retry(ctx, func() error {
 		_, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -129,7 +130,7 @@ func (rc *RockClient) ListViews(ctx context.Context, options ...option.ListViewO
 		err = rc.Retry(ctx, func() error {
 			resp, httpResp, err = q.Execute()
 
-			return NewErrorWithStatusCode(err, httpResp)
+			return rockerr.NewWithStatusCode(err, httpResp)
 		})
 	} else {
 		q := rc.ViewsApi.WorkspaceViews(ctx, opts.Workspace)
@@ -137,7 +138,7 @@ func (rc *RockClient) ListViews(ctx context.Context, options ...option.ListViewO
 		err = rc.Retry(ctx, func() error {
 			resp, httpResp, err = q.Execute()
 
-			return NewErrorWithStatusCode(err, httpResp)
+			return rockerr.NewWithStatusCode(err, httpResp)
 		})
 	}
 
@@ -164,7 +165,7 @@ func (rc *RockClient) GetView(ctx context.Context, workspace, name string) (open
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {

--- a/views_test.go
+++ b/views_test.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/rockset/rockset-go-client/internal/test"
 	"github.com/rockset/rockset-go-client/option"
 )
 
 func TestListViews(t *testing.T) {
 	rc, _ := vcrTestClient(t, t.Name())
-	ctx := testCtx()
+	ctx := test.Context()
 
 	_, err := rc.ListViews(ctx, option.WithViewWorkspace(persistentWorkspace))
 	require.NoError(t, err)
@@ -18,7 +19,7 @@ func TestListViews(t *testing.T) {
 
 func TestViewCRUD(t *testing.T) {
 	rc, _ := vcrTestClient(t, t.Name())
-	ctx := testCtx()
+	ctx := test.Context()
 
 	ws := "acc"
 	name := randomName("view")

--- a/virtual_instances.go
+++ b/virtual_instances.go
@@ -5,6 +5,7 @@ import (
 	"github.com/rs/zerolog"
 	"net/http"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
 )
@@ -73,7 +74,7 @@ func (rc *RockClient) CreateVirtualInstance(ctx context.Context, name string,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -96,7 +97,7 @@ func (rc *RockClient) DeleteVirtualInstance(ctx context.Context, vID string) (op
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -119,7 +120,7 @@ func (rc *RockClient) GetVirtualInstance(ctx context.Context, vID string) (opena
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -142,7 +143,7 @@ func (rc *RockClient) ListVirtualInstances(ctx context.Context) ([]openapi.Virtu
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -193,7 +194,7 @@ func (rc *RockClient) UpdateVirtualInstance(ctx context.Context, vID string,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -216,7 +217,7 @@ func (rc *RockClient) SuspendVirtualInstance(ctx context.Context, vID string) (o
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -239,7 +240,7 @@ func (rc *RockClient) ResumeVirtualInstance(ctx context.Context, vID string) (op
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -271,7 +272,7 @@ func (rc *RockClient) ListVirtualInstanceQueries(ctx context.Context, vID string
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -294,7 +295,7 @@ func (rc *RockClient) ListCollectionMounts(ctx context.Context, vID string) ([]o
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -318,7 +319,7 @@ func (rc *RockClient) GetCollectionMount(ctx context.Context, vID,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -346,7 +347,7 @@ func (rc *RockClient) MountCollections(ctx context.Context, vID string,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -370,7 +371,7 @@ func (rc *RockClient) UnmountCollection(ctx context.Context, vID string,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {

--- a/virtual_instances_test.go
+++ b/virtual_instances_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rockset/rockset-go-client"
 	"github.com/rockset/rockset-go-client/dataset"
+	"github.com/rockset/rockset-go-client/internal/test"
 	"github.com/rockset/rockset-go-client/option"
 )
 
@@ -35,7 +36,7 @@ func TestVirtualInstance(t *testing.T) {
 }
 
 func (s *VirtualInstanceSuite) TestListQueries() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	queries, err := s.rc.ListVirtualInstanceQueries(ctx, s.vID)
 	s.Require().NoError(err)
@@ -45,7 +46,7 @@ func (s *VirtualInstanceSuite) TestListQueries() {
 }
 
 func (s *VirtualInstanceSuite) TestGetCollectionMount() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	mount, err := s.rc.GetCollectionMount(ctx, s.vID, "commons.movie_releases")
 	s.Require().NoError(err)
@@ -53,7 +54,7 @@ func (s *VirtualInstanceSuite) TestGetCollectionMount() {
 }
 
 func (s *VirtualInstanceSuite) TestListCollectionMounts() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	mounts, err := s.rc.ListCollectionMounts(ctx, s.vID)
 	s.Require().NoError(err)
@@ -61,7 +62,7 @@ func (s *VirtualInstanceSuite) TestListCollectionMounts() {
 }
 
 func (s *VirtualInstanceSuite) TestExecuteQuery() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	result, err := s.rc.ExecuteQueryOnVirtualInstance(ctx, s.vID,
 		"SELECT * from commons._events LIMIT 10")
@@ -70,7 +71,7 @@ func (s *VirtualInstanceSuite) TestExecuteQuery() {
 }
 
 func (s *VirtualInstanceSuite) TestGetVirtualInstance() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	// make sure we can access the VI using both the plain id and the RRN
 	rocksetTestVIs := []string{
@@ -88,7 +89,7 @@ func (s *VirtualInstanceSuite) TestGetVirtualInstance() {
 }
 
 func (s *VirtualInstanceSuite) TestListVirtualInstances() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	vis, err := s.rc.ListVirtualInstances(ctx)
 	s.Require().NoError(err)
@@ -119,7 +120,7 @@ func TestVirtualInstanceIntegration(t *testing.T) {
 }
 
 func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance_0_Create() {
-	ctx := testCtx()
+	ctx := test.Context()
 	t0 := time.Now()
 	rc, _ := vcrTestClient(s.T(), s.T().Name())
 
@@ -140,7 +141,7 @@ func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance_0_Create() {
 }
 
 func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance_1_Collection() {
-	ctx := testCtx()
+	ctx := test.Context()
 	t0 := time.Now()
 	rc, _ := vcrTestClient(s.T(), s.T().Name())
 
@@ -169,7 +170,7 @@ func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance_1_Collection() {
 }
 
 func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance_2_Mount() {
-	ctx := testCtx()
+	ctx := test.Context()
 	t0 := time.Now()
 	rc, _ := vcrTestClient(s.T(), s.T().Name())
 
@@ -190,7 +191,7 @@ func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance_2_Mount() {
 }
 
 func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance_3_Query() {
-	ctx := testCtx()
+	ctx := test.Context()
 	t0 := time.Now()
 	rc, _ := vcrTestClient(s.T(), s.T().Name())
 
@@ -208,7 +209,7 @@ func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance_3_Query() {
 }
 
 func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance_4_Unmount() {
-	ctx := testCtx()
+	ctx := test.Context()
 	t0 := time.Now()
 	rc, _ := vcrTestClient(s.T(), s.T().Name())
 
@@ -225,7 +226,7 @@ func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance_4_Unmount() {
 }
 
 func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance_5_Suspend() {
-	ctx := testCtx()
+	ctx := test.Context()
 	t0 := time.Now()
 	rc, _ := vcrTestClient(s.T(), s.T().Name())
 
@@ -258,7 +259,7 @@ func (s *VirtualInstanceIntegrationSuite) TestVirtualInstance_5_Suspend() {
 }
 
 func (s *VirtualInstanceIntegrationSuite) TearDownSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 
 	err := s.rc.DeleteCollection(ctx, s.workspace, s.collection)
 	s.Assert().NoError(err)

--- a/wait.go
+++ b/wait.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/rs/zerolog"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/option"
 )
 
@@ -164,7 +166,7 @@ func resourceIsAvailable(ctx context.Context, fn func(ctx context.Context) error
 			return false, nil
 		}
 
-		var re Error
+		var re rockerr.Error
 		if errors.As(err, &re) {
 			if re.IsNotFoundError() {
 				// the resource is not present, retry
@@ -187,7 +189,7 @@ func resourceIsGone(ctx context.Context, fn func(ctx context.Context) error) Ret
 			return true, nil
 		}
 
-		var re Error
+		var re rockerr.Error
 		if errors.As(err, &re) {
 			if re.IsNotFoundError() {
 				// the resource is no longer present
@@ -231,7 +233,7 @@ func (d *docWaiter) collectionHasNewDocs(ctx context.Context, workspace, name st
 		zl := zerolog.Ctx(ctx)
 		c, err := d.rc.GetCollection(ctx, workspace, name)
 		if err != nil {
-			re := NewError(err)
+			re := rockerr.New(err)
 			if re.Retryable() {
 				return true, nil
 			}
@@ -261,7 +263,7 @@ func (d *docWaiter) collectionHasDocs(ctx context.Context, workspace, name strin
 		zl := zerolog.Ctx(ctx)
 		c, err := d.rc.GetCollection(ctx, workspace, name)
 		if err != nil {
-			re := NewError(err)
+			re := rockerr.New(err)
 			if re.Retryable() {
 				return true, nil
 			}

--- a/wait_test.go
+++ b/wait_test.go
@@ -3,12 +3,14 @@ package rockset
 import (
 	"context"
 	"fmt"
-	"github.com/rockset/rockset-go-client/openapi"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	
+	rockerr "github.com/rockset/rockset-go-client/errors"
+	"github.com/rockset/rockset-go-client/openapi"
 )
 
 type WaitTestSuite struct {
@@ -29,7 +31,7 @@ func (s *WaitTestSuite) TestResourceIsAvailable() {
 
 		switch counter {
 		case 0:
-			return Error{
+			return rockerr.Error{
 				ErrorModel: &openapi.ErrorModel{},
 				StatusCode: http.StatusNotFound,
 				Cause:      fmt.Errorf("resource not present"),
@@ -65,7 +67,7 @@ func (s *WaitTestSuite) TestResourceIsGone() {
 		case 0:
 			return nil
 		case 1:
-			return Error{
+			return rockerr.Error{
 				ErrorModel: &openapi.ErrorModel{},
 				StatusCode: http.StatusNotFound,
 				Cause:      fmt.Errorf("resource not present"),

--- a/workspaces.go
+++ b/workspaces.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	rockerr "github.com/rockset/rockset-go-client/errors"
 	"github.com/rockset/rockset-go-client/openapi"
 	"github.com/rockset/rockset-go-client/option"
 )
@@ -34,7 +35,7 @@ func (rc *RockClient) CreateWorkspace(ctx context.Context, workspace string,
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Body(*req).Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -58,7 +59,7 @@ func (rc *RockClient) GetWorkspace(ctx context.Context, workspace string) (opena
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -84,7 +85,7 @@ func (rc *RockClient) ListWorkspaces(ctx context.Context) ([]openapi.Workspace, 
 	err = rc.Retry(ctx, func() error {
 		resp, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {
@@ -106,7 +107,7 @@ func (rc *RockClient) DeleteWorkspace(ctx context.Context, name string) error {
 	err = rc.Retry(ctx, func() error {
 		_, httpResp, err = q.Execute()
 
-		return NewErrorWithStatusCode(err, httpResp)
+		return rockerr.NewWithStatusCode(err, httpResp)
 	})
 
 	if err != nil {

--- a/workspaces_test.go
+++ b/workspaces_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/rockset/rockset-go-client"
+	rockerr "github.com/rockset/rockset-go-client/errors"
+	"github.com/rockset/rockset-go-client/internal/test"
 	"github.com/rockset/rockset-go-client/option"
 )
 
@@ -27,7 +29,7 @@ func TestSuiteWorkspace(t *testing.T) {
 }
 
 func (s *SuiteWorkspace) SetupSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 	_, err := s.rc.CreateWorkspace(ctx, s.ws,
 		option.WithWorkspaceDescription(description()))
 	s.Require().NoError(err)
@@ -36,7 +38,7 @@ func (s *SuiteWorkspace) SetupSuite() {
 }
 
 func (s *SuiteWorkspace) TearDownSuite() {
-	ctx := testCtx()
+	ctx := test.Context()
 	err := s.rc.DeleteWorkspace(ctx, s.ws)
 	s.Require().NoError(err)
 	err = s.rc.WaitUntilWorkspaceGone(ctx, s.ws)
@@ -44,30 +46,30 @@ func (s *SuiteWorkspace) TearDownSuite() {
 }
 
 func (s *SuiteWorkspace) TestGetWorkspace() {
-	ctx := testCtx()
+	ctx := test.Context()
 	ws, err := s.rc.GetWorkspace(ctx, s.ws)
 	s.Require().NoError(err)
 	s.Require().Equal(s.ws, ws.GetName())
 }
 
 func (s *SuiteWorkspace) TestGetPersistentWorkspace() {
-	ctx := testCtx()
+	ctx := test.Context()
 	ws, err := s.rc.GetWorkspace(ctx, persistentWorkspace)
 	s.Require().NoError(err)
 	s.Require().Equal(persistentWorkspace, ws.GetName())
 }
 
 func (s *SuiteWorkspace) TestGetNonExistingWorkspace() {
-	ctx := testCtx()
+	ctx := test.Context()
 	_, err := s.rc.GetWorkspace(ctx, randomString(16))
 	s.Require().Error(err)
-	var re rockset.Error
+	var re rockerr.Error
 	s.Require().True(errors.As(err, &re))
 	s.Assert().True(re.IsNotFoundError())
 }
 
 func (s *SuiteWorkspace) TestListWorkspace() {
-	ctx := testCtx()
+	ctx := test.Context()
 	list, err := s.rc.ListWorkspaces(ctx)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(list)

--- a/writer_test.go
+++ b/writer_test.go
@@ -2,17 +2,18 @@ package rockset_test
 
 import (
 	"context"
-	"github.com/rockset/rockset-go-client/option"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/rockset/rockset-go-client"
+	"github.com/rockset/rockset-go-client/internal/test"
 	"github.com/rockset/rockset-go-client/openapi"
+	"github.com/rockset/rockset-go-client/option"
 )
 
 type testObject struct {
@@ -54,7 +55,7 @@ func TestWriterSuite(t *testing.T) {
 }
 
 func (s *WriterSuite) TestWriter() {
-	ctx := testCtx()
+	ctx := test.Context()
 	c := rockset.WriterConfig{
 		BatchDocumentCount: 30,
 		FlushInterval:      time.Millisecond * 50,
@@ -82,7 +83,7 @@ func (s *WriterSuite) TestWriter() {
 }
 
 func (s *WriterSuite) TestCancellation() {
-	ctx, cancel := context.WithCancel(testCtx())
+	ctx, cancel := context.WithCancel(test.Context())
 	c := rockset.WriterConfig{
 		BatchDocumentCount: 30,
 		FlushInterval:      time.Millisecond * 20,
@@ -113,7 +114,7 @@ func (s *WriterSuite) TestCancellation() {
 }
 
 func (s *WriterSuite) TestShutdown() {
-	ctx := testCtx()
+	ctx := test.Context()
 	c := rockset.WriterConfig{
 		BatchDocumentCount: 30,
 		FlushInterval:      time.Millisecond * 500,
@@ -165,7 +166,7 @@ func BenchmarkWriter100(b *testing.B) {
 }
 
 func benchmarkWriter(b *testing.B, c rockset.WriterConfig) {
-	ctx := testCtx()
+	ctx := test.Context()
 	fa := &fakeAdder{}
 	w, err := rockset.NewWriter(c, fa)
 	require.NoError(b, err)
@@ -190,8 +191,8 @@ func benchmarkWriter(b *testing.B, c rockset.WriterConfig) {
 // go tool pprof -http=:8080 cpu.out
 
 func TestWriterIntegration(t *testing.T) {
-	skipUnlessIntegrationTest(t)
-	ctx := testCtx()
+	test.SkipUnlessIntegrationTest(t)
+	ctx := test.Context()
 
 	rc, err := rockset.NewClient()
 	require.Nil(t, err)


### PR DESCRIPTION
first in a series of refactoring to make distinct packages of non-core functionality,
and remove cyclic package dependencies which will arise when moving the wait functionality
into its own package
