### PR TITLE
allow custom conversion function for the writer

### DIFF
--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -62,6 +62,7 @@ func (s *WriterSuite) TestWriter() {
 	c := writer.Config{
 		BatchDocumentCount: 30,
 		FlushInterval:      flushInterval,
+		ConversionFn:       writer.JSONConversion,
 	}
 	fa := &fakeAdder{}
 	w, err := writer.New(c, fa)


### PR DESCRIPTION
the `structs.Map()` conversion doesn't honor json tags on the struct,
so we need a way to allow them to be used
